### PR TITLE
test: actualizar test unitario de AuthController para usar refresh_token

### DIFF
--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -51,11 +51,11 @@ describe ('AuthController', () => {
 
   it ('Debe renovar el accsess token usando refresh token', async () => {
 
-    const dto = { userId: '550e8400-e29b-41d4-a716-446655440000' };
-    const expectedtoken = { access_token: 'nuevo-token'};
+    const dto = { refresh_token: 'refresh123' };
+    const expectedtoken = { access_token: 'refresh123'};
     authService.refreshAccessToken.mockResolvedValue (expectedtoken); 
     const result = await controller.refresh (dto);  
-    expect (authService.refreshAccessToken).toHaveBeenCalledWith (dto.userId);
+    expect (authService.refreshAccessToken).toHaveBeenCalledWith (dto.refresh_token);
     expect (result).toEqual (expectedtoken);
 
   })


### PR DESCRIPTION
test(auth): actualizar test para usar refresh_token en lugar de userId (#41)

Se actualizó el test unitario de AuthController para utilizar refresh_token en lugar de userId, en línea con la nueva definición de RefreshDto.