### PR TITLE
fix: uuid

### DIFF
--- a/src/modules/transactions/entities/transaction.entity.ts
+++ b/src/modules/transactions/entities/transaction.entity.ts
@@ -3,29 +3,37 @@ import { ReceiverFinancialAccount } from '@financial-accounts/receiver-financial
 import { SenderFinancialAccount } from '@financial-accounts/sender-financial-accounts/entities/sender-financial-account.entity';
 import { Amount } from '@transactions/amounts/entities/amount.entity';
 import { TransactionStatus } from 'src/enum/trasanction-status.enum';
+
 import {
   Entity,
-  PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
   ManyToOne,
   JoinColumn,
   OneToOne,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  OneToMany,
+  BeforeInsert,
+  PrimaryColumn,
 } from 'typeorm';
 
+import { customAlphabet } from 'nanoid';
 import { Note } from '@transactions/notes/entities/note.entity';
 import { Regret } from '@transactions/regrets/entities/regrets.entity';
 import { UserDiscount } from '@users/entities/user-discount.entity';
 
+const nanoidCustom = customAlphabet(
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
+  8,
+);
+
 @Entity('transactions')
 export class Transaction {
-  @PrimaryGeneratedColumn('uuid', { name: 'transaction_id' })
+  @PrimaryColumn({ name: 'transaction_id', type: 'varchar', length: 8 })
   id: string;
 
-  // @Column({ name: 'payments_id' })
-  // paymentsId: string; //para el recibo proof of payments
+  @BeforeInsert()
+  generateId() {
+    this.id = nanoidCustom(); // genera un string de 8 caracteres sin "-" ni "_"
+  }
 
   @Column({ name: 'country_transaction' })
   countryTransaction: string;


### PR DESCRIPTION
### **Contexto:**
Se cambió la generación de IDs en el módulo transactions de uuid (IDs largos) a nanoid con un alfabeto personalizado que genera IDs cortos de 8 caracteres alfanuméricos sin caracteres especiales.

### **Cambios realizados:**

- Reemplazo de uuid por nanoid con alfabeto limpio (A-Z, a-z, 0-9) y longitud 8.

- Actualización del método @BeforeInsert en la entidad Transaction.

- Eliminación de caracteres - y _ en los IDs generados.

### **Impacto:**

- IDs más cortos y legibles.

- Menor tamaño en URLs y payloads.

- Mismo nivel de unicidad y seguridad.

**### Cómo probarlo:**

- Crear una transacción y verificar que el ID tiene 8 caracteres alfanuméricos sin caracteres especiales.

- Confirmar que la creación funciona correctamente.

- Ejecutar las pruebas (npm run test).

