### PR TITLE
feat(verification): Agregar soporte de paginación a la lista de verificacion de usuario

### DIFF
--- a/src/modules/users/dto/create-user-verification.dto.ts
+++ b/src/modules/users/dto/create-user-verification.dto.ts
@@ -1,6 +1,7 @@
-import { IsString, IsOptional, IsEnum, IsNotEmpty } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional, IsEnum, IsNotEmpty, IsInt, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { VerificationStatus } from '@users/entities/user-verification.entity';
+import { Type } from 'class-transformer';
 
 
 
@@ -55,4 +56,18 @@ export class GetVerificationsQueryDto {
       'El status debe ser uno de: pending, verified, rejected, resend-data',
   })
   status?: VerificationStatus;
+
+  @ApiPropertyOptional({ description: 'Número de página', example: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ description: 'Cantidad de resultados por página', example: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 10;
 }

--- a/src/modules/users/verification/user-verification.service.ts
+++ b/src/modules/users/verification/user-verification.service.ts
@@ -111,19 +111,24 @@ export class UserVerificationService {
     return verification;
   }
 
-  async findVerificationsByStatus(
+async findVerificationsByStatus(
   status?: VerificationStatus,
-): Promise<UserVerification[]> {
-  const whereCondition = status
-    ? { verification_status: status }
-    : {}; // si no se pasa, trae todas
+  page: number = 1,
+  limit: number = 10,
+): Promise<{ data: UserVerification[]; total: number }> {
+  const whereCondition = status ? { verification_status: status } : {};
 
-  return this.userVerificationRepository.find({
+  const [data, total] = await this.userVerificationRepository.findAndCount({
     where: whereCondition,
-     relations: ['user', 'user.profile'], // Aquí asumes que en la entidad UserVerification tienes: @ManyToOne(() => User, user => user.verifications) user;
+    relations: ['user', 'user.profile'],
     order: { created_at: 'DESC' },
+    skip: (page - 1) * limit,
+    take: limit,
   });
+
+  return { data, total };
 }
+
 
 async findVerificationById(verificationId: string): Promise<UserVerification | null> {
   return this.userVerificationRepository.findOne({


### PR DESCRIPTION
Resumen
Este Pull Request agrega soporte de paginación a la funcionalidad de listado de verificaciones de usuario.
Se implementó la lógica necesaria en el servicio y el controlador, y se actualizó la documentación de Swagger para reflejar los nuevos parámetros y el formato de respuesta.

Con estos cambios, la API permitirá una mejor gestión de grandes volúmenes de datos, mejorando la experiencia de los consumidores del servicio.

Cambios Realizados
DTO:
Se modificó GetVerificationsQueryDto para incluir los parámetros page y limit.

Servicio:
Se actualizó findVerificationsByStatus para usar findAndCount y retornar datos junto con el conteo total.

Controlador:
Se implementó la lógica de paginación en listPending y se ajustó la respuesta con pagination (page, limit, total).

Swagger:
Se atualizó la documentación para reflejar la respuesta paginada correctamente.

Notas
Este cambio es compatible con versiones anteriores, ya que page y limit son opcionales.
No hay impacto en otras áreas del sistema.

