### PR TITLE
fix: corrección al validar página 0 o negativa en preguntas paginadas

### DIFF
--- a/src/modules/questions/dto/create-question.dto.ts
+++ b/src/modules/questions/dto/create-question.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateQuestionDto {
   // @IsString()
@@ -12,15 +13,15 @@ export class CreateQuestionDto {
     example: '¿Cómo se usa la app?',
     description: 'Título de la pregunta frecuente',
   })
-  // @IsString()
-  // @IsNotEmpty()
+  @IsString()
+  @IsNotEmpty()
   title: string;
 
   @ApiProperty({
     example: 'Para usar la app, primero debés registrarte...',
     description: 'Descripción de la pregunta frecuente',
   })
-  //@IsString()
-  //@IsNotEmpty()
+  @IsString()
+  @IsNotEmpty()
   description: string;
 }

--- a/src/modules/questions/questions.controller.ts
+++ b/src/modules/questions/questions.controller.ts
@@ -70,7 +70,7 @@ export class QuestionsController {
   @ApiResponse ({
 
     status: 400,
-    description: 'El parámetro "page" debe ser un número entero positivo mayor a 0',
+    description: 'El parámetro "page" debe ser un número',
 
   })
 
@@ -92,19 +92,20 @@ export class QuestionsController {
 
         const pageNumber = parseInt (page, 10);
 
-        if (isNaN (pageNumber) || pageNumber <= 0 ) {
+        if (isNaN (pageNumber)) {
 
           throw new BadRequestException (
 
-            'El parámetro "page" debe ser un número entero positivo mayor a 0.',
+            'El parámetro "page" debe ser un número válido',
 
-          );
+          );          
 
         }
 
+        const currentPage = pageNumber <= 0 ? 1 : pageNumber;
         const limit = 9;
-        const result = await this.questionsService.findAllPaginated (pageNumber, limit);
-        return Promise.resolve (result);
+        return await this.questionsService.findAllPaginated(currentPage, limit);
+
 
       } catch (error) {
 


### PR DESCRIPTION
fix: corrección al validar página 0 o negativa en preguntas paginadas (#53)

Contexto: Se detectó que cuando se ingresaba `page=0` o un número negativo en el endpoint paginado de preguntas, se mostraba error o no se comportaba como se esperaba.

Cambios realizados:

- Se fuerza `page = 1` si el valor ingresado es 0 o menor.
- Se lanza un error 400 si el valor no es un número válido.

Impacto: Mejora la experiencia del usuario y la robustez del endpoint paginado.

Cómo probarlo:

- GET /questions/paginated?page=0 → devuelve página 1
- GET /questions/paginated?page=a → error 400
