### PR TITLE
feat(transactions): agregar endpoint público para historial de estados por apellido del remitente

### DIFF
--- a/src/common/interfaces/status-history.interface.ts
+++ b/src/common/interfaces/status-history.interface.ts
@@ -14,3 +14,11 @@ export interface StatusHistoryResponse {
   changedByAdminId: string;
   additionalData?: Record<string, any>;
 }
+
+
+export interface UserStatusHistoryResponse {
+  id: string;
+  status: AdminStatus;
+  changedAt: Date;
+  message: string;
+}

--- a/src/modules/financial-accounts/receiver-financial-accounts/entities/receiver-financial-account.entity.ts
+++ b/src/modules/financial-accounts/receiver-financial-accounts/entities/receiver-financial-account.entity.ts
@@ -13,6 +13,6 @@ export class ReceiverFinancialAccount extends FinancialAccount {
   @Column({ name: 'email' })
   email: string;
 
-  @OneToMany(() => Transaction, (transaction) => transaction.senderAccount)
+  @OneToMany(() => Transaction, (transaction) => transaction.receiverAccount)
   transactions: Transaction[];
 }

--- a/src/modules/financial-accounts/sender-financial-accounts/entities/sender-financial-account.entity.ts
+++ b/src/modules/financial-accounts/sender-financial-accounts/entities/sender-financial-account.entity.ts
@@ -4,9 +4,12 @@ import { FinancialAccount } from '@financial-accounts/entities/financial-account
 
 @ChildEntity('sender')
 export class SenderFinancialAccount extends FinancialAccount {
-  @OneToMany(() => Transaction, (transaction) => transaction.receiverAccount)
+  @OneToMany(() => Transaction, (transaction) => transaction.senderAccount)
   transactions: Transaction[];
 
   @Column({ nullable: true })
   email?: string;
+
+  @Column({ nullable: true })
+  phoneNumber?: string;
 }

--- a/src/modules/transactions/dto/user-status-history.dto.ts
+++ b/src/modules/transactions/dto/user-status-history.dto.ts
@@ -1,0 +1,61 @@
+import { Type } from 'class-transformer';
+import { IsBoolean, IsString, IsArray, IsDate, ValidateNested } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class StatusHistoryItemDto {
+  @ApiProperty({
+    description: 'Identificador único del registro de historial',
+    example: 'c4b1f279-70a8-42c5-90d7-56a76feb2e2d',
+  })
+  @IsString()
+  id: string;
+
+  @ApiProperty({
+    description: 'Estado actual de la transacción',
+    example: 'review_payment',
+  })
+  @IsString()
+  status: string;
+
+  @ApiProperty({
+    description: 'Fecha y hora en que se realizó el cambio de estado',
+    example: '2025-08-08T17:02:04.584Z',
+    type: String,
+    format: 'date-time',
+  })
+  @IsDate()
+  @Type(() => Date)
+  changedAt: Date;
+
+  @ApiProperty({
+    description: 'Mensaje o descripción asociada al cambio de estado',
+    example: 'Aprobación automática tras revisión',
+  })
+  @IsString()
+  message: string;
+}
+
+export class UserStatusHistoryResponseDto {
+  @ApiProperty({
+    description: 'Indica si la operación fue exitosa',
+    example: true,
+  })
+  @IsBoolean()
+  success: boolean;
+
+  @ApiProperty({
+    description: 'Mensaje informativo sobre el resultado',
+    example: 'Historial obtenido correctamente',
+  })
+  @IsString()
+  message: string;
+
+  @ApiProperty({
+    description: 'Lista con los registros del historial de estados',
+    type: [StatusHistoryItemDto],
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => StatusHistoryItemDto)
+  data: StatusHistoryItemDto[];
+}

--- a/src/modules/transactions/entities/transaction.entity.ts
+++ b/src/modules/transactions/entities/transaction.entity.ts
@@ -55,14 +55,14 @@ export class Transaction {
   })
   finalStatus: TransactionStatus;
 
-  @ManyToOne(() => SenderFinancialAccount, (sender) => sender.transactions)
-  @JoinColumn({ name: 'sender_account_id' })
+  @ManyToOne(() => SenderFinancialAccount, 
+    (sender) => sender.transactions)
+    @JoinColumn({ name: 'sender_account_id' })
   senderAccount: SenderFinancialAccount;
 
   @ManyToOne(
     () => ReceiverFinancialAccount,
-    (receiver) => receiver.transactions,
-  )
+    (receiver) => receiver.transactions,)
   @JoinColumn({ name: 'receiver_account_id' })
   receiverAccount: ReceiverFinancialAccount;
 

--- a/src/modules/transactions/transactions.module.ts
+++ b/src/modules/transactions/transactions.module.ts
@@ -13,6 +13,7 @@ import { FileUploadService } from '../file-upload/file-upload.service';
 import { ProofOfPayment } from '@financial-accounts/proof-of-payments/entities/proof-of-payment.entity';
 import { CloudinaryService } from 'src/service/cloudinary/cloudinary.service';
 import { UserDiscount } from '@users/entities/user-discount.entity';
+import { AdministracionStatusLog } from '@admin/entities/administracion-status-log.entity';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { UserDiscount } from '@users/entities/user-discount.entity';
       Amount,
       UserDiscount,
       ProofOfPayment,
+      AdministracionStatusLog,
     ]),
     FinancialAccountsModule,
   ],


### PR DESCRIPTION
Descripción del Pull Request
Se implementa un nuevo endpoint público GET /transactions/status/:id que permite consultar el historial de estados de una transacción validando que el apellido del remitente coincida con el parámetro lastName proporcionado por query.

Este cambio incluye:

Creación del método getPublicStatusHistory en el servicio de transacciones.

Definición del DTO UserStatusHistoryResponseDto para estructurar la respuesta.

Actualización del controlador para exponer el endpoint y manejar validaciones y errores (401, 404).

Documentación completa del endpoint con Swagger para facilitar su uso y pruebas.

Corrección y verificación de relaciones entre entidades para asegurar integridad.

Con esta mejora, se brinda un acceso seguro y controlado para que los usuarios puedan consultar información relevante de sus transacciones sin comprometer la privacidad ni la seguridad del sistema.