### PR TITLE
feat(notes): implementación de OTP para creación y cambio de carga de URL a imagen

### DIFF
--- a/src/config/otp.config.ts
+++ b/src/config/otp.config.ts
@@ -1,0 +1,23 @@
+
+
+import { registerAs } from '@nestjs/config';
+
+export default registerAs ('otp', () => {
+  
+  const jwtSecret = process.env.OTP_JWT_SECRET;
+
+  if (process.env.NODE_ENV === 'production' && !jwtSecret) {
+
+    throw new Error ('Missing OTP_JWT_SECRET in environment variables');
+
+  }
+
+  return {
+
+    jwtSecret: jwtSecret || 'supersecret', 
+    ttl: parseInt(process.env.OTP_TTL || '300', 10),
+
+  };
+
+});
+

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -1,3 +1,5 @@
+
+
 import { registerAs } from '@nestjs/config';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 
@@ -14,7 +16,7 @@ export default registerAs('typeorm', (): TypeOrmModuleOptions => {
     ssl: isProduction
       ? { rejectUnauthorized: false } // SSL activado en producción
       : false, // SSL desactivado en desarrollo
-    synchronize: !isProduction,
-    entities: ['dist/**/*.entity.{ts,js}'],
+    synchronize:!isProduction,
+    entities: ['dist/**//**.entity.{ts,js}'],
   };
 });

--- a/src/modules/transactions/entities/transaction.entity.ts
+++ b/src/modules/transactions/entities/transaction.entity.ts
@@ -1,3 +1,5 @@
+
+
 import { ProofOfPayment } from '@financial-accounts/proof-of-payments/entities/proof-of-payment.entity';
 import { ReceiverFinancialAccount } from '@financial-accounts/receiver-financial-accounts/entities/receiver-financial-account.entity';
 import { SenderFinancialAccount } from '@financial-accounts/sender-financial-accounts/entities/sender-financial-account.entity';
@@ -82,6 +84,13 @@ export class Transaction {
 
   @OneToOne(() => UserDiscount, (userDiscount) => userDiscount.transaction)
   userDiscount: UserDiscount;
+
+  @Column ({ default: false })
+  isNoteVerified: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  noteVerificationExpiresAt?: Date;
+
 }
 
 // Relaciones de Transacciones y Pagos

--- a/src/modules/transactions/notes/dto/create-note.dto.ts
+++ b/src/modules/transactions/notes/dto/create-note.dto.ts
@@ -1,0 +1,19 @@
+
+
+import { IsString } from 'class-validator';
+import { ApiProperty} from '@nestjs/swagger';
+
+export class CreateNoteDto {
+
+  @IsString ()
+
+  @ApiProperty ({
+
+    description: 'Mensaje asociado a la transacción',
+    example: 'Pago recibido correctamente',
+
+  })
+
+  message: string;
+
+}

--- a/src/modules/transactions/notes/dto/request-note-code.dto.ts
+++ b/src/modules/transactions/notes/dto/request-note-code.dto.ts
@@ -1,0 +1,18 @@
+
+
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RequestNoteCodeDto {
+
+  @IsString ()
+  @ApiProperty ({
+
+    description: 'ID de la transacción para la que se solicita el código OTP',
+    example: 'uuid-transaccion',
+
+  })
+
+  transactionId: string;
+  
+}

--- a/src/modules/transactions/notes/notes.controller.ts
+++ b/src/modules/transactions/notes/notes.controller.ts
@@ -1,4 +1,4 @@
-import {
+/*import {
   Controller,
   Get,
   Post,
@@ -157,6 +157,459 @@ export class NotesController {
     }
   }
 
+  @ApiOperation({ summary: 'Eliminar una nota' })
+  @ApiResponse({
+    status: 200,
+    description: 'Nota eliminada correctamente',
+    schema: {
+      example: { message: 'Nota eliminada correctamente' },
+    },
+  })
+  @ApiParam({ name: 'id', description: 'ID de la nota', example: 'uuid' })
+  @Delete(':id')
+  async remove(@Param('id') id: string) {
+    try {
+      return await this.notesService.remove(id);
+    } catch (error) {
+      throw new HttpException(
+        'Error al eliminar la nota: ' + error.message,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}*/
+
+
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+  BadRequestException,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
+import { Req } from '@nestjs/common';
+import { NotesService } from './notes.service';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiParam,
+  ApiHeader,
+  ApiConsumes,
+} from '@nestjs/swagger';
+import { TransactionsService } from '@transactions/transactions.service';
+import { OtpService } from '@otp/otp.service';
+import { ValidateNoteCodeDto } from './dto/validate-note-code.dto';
+import { RequestNoteCodeDto } from './dto/request-note-code.dto';
+import { CreateNoteDto } from './dto/create-note.dto';
+import { FileInterceptor } from '@nestjs/platform-express';
+
+
+@ApiTags ('Notas')
+@Controller ('notes')
+
+export class NotesController {
+
+  constructor (
+
+    private readonly notesService: NotesService,
+    private readonly transactionsService: TransactionsService, 
+    private readonly otpService: OtpService, 
+
+  ) {}
+  
+  @ApiOperation ({ summary: 'Solicitar acceso para crear una nota mediante OTP' })
+
+  @ApiBody ({
+
+    schema: {
+
+      example: {
+
+        transactionId: 'wFHi5iOLbC',
+
+      },
+
+    },
+
+  })
+
+  @ApiResponse ({
+
+    status: 200,
+    description: 'Código enviado con éxito al correo asociado.',
+
+    schema: {
+
+      example: {
+
+        message: 'Código enviado con éxito al correo asociado.',
+        code_sent: true,
+
+      },
+
+    },
+
+  })
+
+  @Post ('request-access')
+
+  async requestAccess (@Body () dto: RequestNoteCodeDto) {
+
+    const { transactionId } = dto;
+
+    const transaction = await this.transactionsService.findOne (transactionId, {
+
+      relations: ['senderAccount', 'receiverAccount'],
+
+    });
+
+    if (!transaction) {
+
+      throw new NotFoundException ('Transacción no encontrada');
+
+    }
+
+    const email = transaction.senderAccount?.createdBy;
+
+    if (!email) {
+
+      throw new BadRequestException (
+
+        'No se encontró un email asociado a la transacción',
+
+      );
+
+    }
+
+    await this.otpService.sendOtpToEmail (email);
+
+    return {
+
+      message: 'Código enviado con éxito al correo asociado.',
+      code_sent: true,
+
+    };
+
+  }
+
+@ApiOperation ({ summary: 'Verifica el código OTP para una transacción' })
+
+@ApiBody ({
+
+  schema: {
+
+    example: { transaction_id: '123', code: '123' },
+
+  },
+
+})
+
+@ApiResponse ({
+
+  status: 200,
+  description: 'Código verificado y transacción retornada',
+
+  schema: {
+
+    example: {
+
+      transaction: {
+
+        id: 'uuid',
+        amount: 50000,
+        currency: 'COP',
+        senderAccount: { id: 'uuid-sender', email: 'sender@mail.com' },
+        receiverAccount: { id: 'uuid-receiver', email: 'receiver@mail.com', paymentMethod: { type: 'PIX' } },
+        createdAt: '2024-01-01T00:00:00Z',
+
+      },
+
+    },
+
+  },
+
+})
+  
+@Post ('verify-code')
+
+async verifyNoteCode (@Body () dto: ValidateNoteCodeDto) {
+
+  const transaction = await this.transactionsService.findOne (dto.transaction_id, {
+
+    relations: [
+
+      'senderAccount',
+      'receiverAccount',
+      'receiverAccount.paymentMethod',
+      'amount',
+
+    ],
+
+  });
+
+  if (!transaction) {
+
+    throw new NotFoundException ('Transacción no encontrada');
+
+  }
+
+  const email = transaction.senderAccount.createdBy;
+
+  if (!email)  {
+    
+    throw new BadRequestException ('Email no asociado a la transacción');
+
+  }
+
+  await this.otpService.validateOtpAndGetUser (email, dto.code);
+  await this.notesService.markTransactionAsVerified (dto.transaction_id);
+  const accessToken = this.otpService.generateOtpToken (dto.transaction_id);
+
+  return {
+
+    transaction,
+    noteAccessToken: accessToken,
+    expiresIn: '5m',
+
+  };  
+
+}
+
+  @ApiOperation ({ summary: 'Crear una nota para una transacción' })
+
+  @ApiResponse ({
+
+    status: 201,
+    
+    description: 'Nota creada correctamente',
+
+    schema: {
+
+      example: {
+
+        note_id: 'uuid',
+        message: 'Nota de prueba',
+        img_url: 'https://url.com/nota.png',
+        createdAt: '2024-01-01T00:00:00Z',
+        transaction: { id: 'uuid-transaccion' },
+
+      },
+
+    },
+
+  })
+
+  @UseInterceptors(FileInterceptor ('image'))
+  @ApiConsumes ('multipart/form-data')
+
+  @ApiParam ({
+
+    name: 'transactionId',
+    description: 'ID de la transacción',
+    example: 'uuid-transaccion',
+
+  })
+
+  @ApiBody ({
+
+  description: 'Datos para crear una nota con imagen opcional',
+  schema: {
+
+    type: 'object',
+
+    properties: {
+
+      message: { type: 'string', example: 'Pago recibido correctamente' },
+
+      image: {
+
+        type: 'string',
+        format: 'binary',
+        description: 'Archivo de imagen opcional',
+
+      },
+
+    },
+
+    required: ['message'],
+
+  },
+
+})
+
+  @ApiHeader ({
+
+  name: 'note-access-token',
+  description: 'Token temporal devuelto por /notes/verify-code',
+  required: true,
+
+  })
+
+  @Post (':transactionId')
+
+  async create (
+
+    @Param ('transactionId') transactionId: string,
+    @UploadedFile() file: Express.Multer.File,
+    @Body () createNoteDto: CreateNoteDto,
+    @Req() req: Request
+
+  ) {
+
+    const token = req.headers ['note-access-token'] as string;
+    if (!token) throw new BadRequestException ('Falta el header note-access-token');
+
+    try {
+
+      return await this.notesService.create (
+
+      transactionId,
+      createNoteDto,
+      token, 
+      file
+
+      );
+
+      } catch (error) {
+
+      throw new HttpException (
+      error.message || 'Error interno al crear la nota',
+      error.status || HttpStatus.INTERNAL_SERVER_ERROR
+
+      );
+
+    }
+
+  }
+  
+  @ApiOperation ({ summary: 'Obtener todas las notas' })
+
+  @ApiResponse ({
+
+    status: 200,
+    description: 'Lista de notas',
+
+    schema: {
+
+      example: [
+
+        {
+
+          note_id: 'uuid',
+          message: 'Nota de prueba',
+          img_url: 'https://url.com/nota.png',
+          createdAt: '2024-01-01T00:00:00Z',
+          transaction: { id: 'uuid-transaccion' },
+
+        },
+
+      ],
+
+    },
+
+  })
+
+  @Get ()
+
+  async findAll () {
+
+    try {
+
+      return await this.notesService.findAll();
+
+    } catch (error) {
+
+      throw new HttpException ( 
+
+        'Error al obtener las notas: ' + error.message,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+
+      );
+
+    }
+
+  }
+
+  @ApiOperation ({ summary: 'Obtener una nota por ID' })
+
+  @ApiResponse ({
+
+    status: 200,
+    description: 'Nota encontrada',
+
+    schema: {
+
+      example: {
+
+        note_id: 'uuid',
+        message: 'Nota de prueba',
+        img_url: 'https://url.com/nota.png',
+        createdAt: '2024-01-01T00:00:00Z',
+        transaction: { id: 'uuid-transaccion' },
+
+      },
+
+    },
+
+  })
+  
+  @ApiParam({ name: 'id', description: 'ID de la nota', example: 'uuid' })
+  @Get(':id')
+  async findOne(@Param('id') id: string) {
+    try {
+      return await this.notesService.findOne(id);
+    } catch (error) {
+      throw new HttpException(
+        'Error al obtener la nota: ' + error.message,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+  @ApiOperation({ summary: 'Actualizar una nota' })
+  @ApiResponse({
+    status: 200,
+    description: 'Nota actualizada correctamente',
+    schema: {
+      example: {
+        note_id: 'uuid',
+        message: 'Nota actualizada',
+        img_url: 'https://url.com/nota.png',
+        createdAt: '2024-01-01T00:00:00Z',
+        transaction: { id: 'uuid-transaccion' },
+      },
+    },
+  })
+  @ApiParam({ name: 'id', description: 'ID de la nota', example: 'uuid' })
+  @ApiBody({
+    description: 'Datos para actualizar la nota',
+    schema: {
+      example: {
+        message: 'Nota actualizada',
+        img_url: 'https://url.com/nota.png',
+      },
+    },
+  })
+  @Patch(':id')
+  async update(@Param('id') id: string, @Body() updateNoteDto: any) {
+    try {
+      return await this.notesService.update(id, updateNoteDto);
+    } catch (error) {
+      throw new HttpException(
+        'Error al actualizar la nota: ' + error.message,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
   @ApiOperation({ summary: 'Eliminar una nota' })
   @ApiResponse({
     status: 200,

--- a/src/modules/transactions/notes/notes.module.ts
+++ b/src/modules/transactions/notes/notes.module.ts
@@ -1,12 +1,22 @@
+
+
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Note } from './entities/note.entity';
 import { Transaction } from '@transactions/entities/transaction.entity';
 import { NotesService } from './notes.service';
 import { NotesController } from './notes.controller';
+import { TransactionsModule } from '@transactions/transactions.module';
+import { OtpModule } from '@otp/otp.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Note, Transaction])],
+  imports: [TypeOrmModule.forFeature([Note, Transaction]),
+
+  OtpModule,
+  TransactionsModule,
+
+  ],
+
   controllers: [NotesController],
   providers: [NotesService],
   exports: [NotesService],

--- a/src/modules/transactions/notes/notes.service.ts
+++ b/src/modules/transactions/notes/notes.service.ts
@@ -1,8 +1,13 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+
+
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Note } from './entities/note.entity';
 import { Transaction } from '@transactions/entities/transaction.entity';
+import { CreateNoteDto } from './dto/create-note.dto';
+import { OtpService } from '@otp/otp.service';
+import { CloudinaryService } from 'src/service/cloudinary/cloudinary.service';
 
 @Injectable()
 export class NotesService {
@@ -10,20 +15,110 @@ export class NotesService {
     @InjectRepository(Note)
     private readonly notesRepository: Repository<Note>,
     @InjectRepository(Transaction)
-    private readonly transactionRepository: Repository<Transaction>,
-  ) {}
+    private readonly transactionRepository: Repository<Transaction>, 
+    private readonly otpService: OtpService,
+    private readonly cloudinaryService: CloudinaryService, 
+    
+) {}
 
-  async create(transactionId: string, createNoteDto: any) {
-    const transaction = await this.transactionRepository.findOne({
-      where: { id: transactionId },
+  async markTransactionAsVerified (transactionId: string): Promise<void> {
+
+    const expiration = new Date();
+    expiration.setMinutes (expiration.getMinutes() + 5);
+
+    await this.transactionRepository.update(transactionId, {
+
+      isNoteVerified: true,
+      noteVerificationExpiresAt: expiration,
+
     });
-    if (!transaction) throw new NotFoundException('Transacción no encontrada');
 
-    const note = this.notesRepository.create({
+  }
+
+  async create (transactionId: string, createNoteDto: CreateNoteDto, token: string, file?: Express.Multer.File) {
+
+    let payload: { transactionId: string };
+
+    try {
+
+      payload = this.otpService.verifyOtpToken (token);
+
+    } catch (err) {
+
+      throw new BadRequestException ('Token inválido o expirado');
+
+    }
+
+    if (payload.transactionId !== transactionId) {
+
+      throw new BadRequestException ('El token no corresponde a esta transacción');
+
+    }
+
+    const transaction = await this.transactionRepository.findOne ({
+
+    where: { id: transactionId },
+
+    });
+
+    if (!transaction) {
+
+      throw new NotFoundException ('Transacción no encontrada');
+
+    }
+
+    if (!transaction.isNoteVerified ||
+
+      !transaction.noteVerificationExpiresAt ||
+
+      new Date() > transaction.noteVerificationExpiresAt
+
+    ) {
+
+        throw new NotFoundException (
+
+          'El acceso para crear nota ha expirado o no está habilitado',
+
+        );
+
+      }
+
+    let img_url: string | undefined;
+    
+    if (file) {
+
+    try {
+
+      img_url = await this.cloudinaryService.uploadFile (
+
+        file.buffer,
+        'notes', 
+        `note-${Date.now()}`,
+
+      );
+
+    } catch (error) {
+
+      throw new BadRequestException (
+
+        'Error al subir la imagen a Cloudinary: ' + error.message,
+
+      );
+
+    }
+
+    }
+
+    const note = this.notesRepository.create ({
+
       ...createNoteDto,
       transaction,
+      img_url,
+
     });
-    return await this.notesRepository.save(note);
+
+    return await this.notesRepository.save (note);
+
   }
 
   async findAll() {
@@ -34,10 +129,12 @@ export class NotesService {
     return notes;
   }
 
-  async findOne(id: string) {
-    const note = await this.notesRepository.findOne({ where: { note_id: id } });
-    if (!note) throw new NotFoundException('Nota no encontrada');
+  async findOne (id: string) {
+
+    const note = await this.notesRepository.findOne ({ where: { note_id: id } });
+    if (!note) throw new NotFoundException ('Nota no encontrada');
     return note;
+
   }
 
   async update(id: string, updateNoteDto: any) {

--- a/src/modules/userAccounts/userAccounts.controller.ts
+++ b/src/modules/userAccounts/userAccounts.controller.ts
@@ -8,6 +8,7 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  Query,
 } from '@nestjs/common';
 import { CreateBankAccountDto } from './dto/create-bank-account.dto';
 import { AccountsService } from './userAccounts.service';
@@ -21,6 +22,7 @@ import {
   ApiResponse,
   ApiBody,
   ApiBearerAuth,
+  ApiQuery,
 } from '@nestjs/swagger';
 
 //TODO: GET (user/accounts/:id) ,  GET (user/user:id/accounts) , GET (user/user:id/accounts/account:id),
@@ -144,11 +146,100 @@ export class AccountsController {
     },
   })
   @UseGuards(JwtAuthGuard, RolesGuard)
-  /*   @Roles('user') */
+  @Roles('user')
   @Get()
   async findAll(@Request() req) {
-    return this.accountsService.findAllByUser(req.user);
+    return this.accountsService.findAllBanks(req.user);
   }
 
-  //GET:ID
+  // Obtener todas las cuentas de banco de un user
+  @ApiOperation({
+    summary: 'Obtener todas las cuentas del usuario autenticado',
+  })
+  @ApiQuery({
+    name: 'userId',
+    required: true,
+    description: 'ID del usuario',
+    type: String,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Lista de cuentas del usuario',
+    schema: {
+      example: [
+        {
+          id: 'uuid',
+          typeAccount: 'bank',
+          formData: {},
+          userAccValues: {
+            first_name: 'Juan',
+            last_name: 'Pérez',
+            identification: '12345678',
+            currency: 'ARS',
+            account_name: 'Cuenta Principal',
+            account_type: 1,
+          },
+        },
+      ],
+    },
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('admin')
+  @Get('/admin/findId')
+  async findOneById(@Query('userId') userId: string) {
+    return this.accountsService.findAllBanks(userId);
+  }
+
+  // obtener una cuenta
+
+  @ApiOperation({
+    summary: 'Obtener una cuenta bancaria específica de un usuario autenticado',
+  })
+  @ApiQuery({
+    name: 'userId',
+    required: true,
+    description: 'ID del usuario',
+    type: String,
+  })
+  @ApiQuery({
+    name: 'bankAccountId',
+    required: true,
+    description: 'ID específico de la cuenta bancaria',
+    type: String,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Cuenta bancaria específica encontrada',
+    schema: {
+      example: {
+        accountName: 'Dylan',
+        currency: 'USD',
+        status: true,
+        payment_type: 'paypal',
+        details: [
+          {
+            account_id: 'f4338078-8c08-468c-ad92-134d37e0b405',
+            email_account: 'dylan.rojo@paypal.com',
+            transfer_code: 987654,
+          },
+        ],
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Cuenta bancaria no encontrada o no pertenece al usuario',
+    schema: {
+      example: { message: 'Cuenta no encontrada para este usuario' },
+    },
+  })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('admin')
+  @Get('/admin/findUserBank')
+  async findOneUserBank(
+    @Query('userId') userId: string,
+    @Query('bankAccountId') bankAccountId: string,
+  ) {
+    return this.accountsService.findOneUserBank(userId, bankAccountId);
+  }
 }


### PR DESCRIPTION
feat(notes): implementación de OTP para creación y cambio de carga de URL a imagen (#67)

Contexto

Se necesitaba implementar un flujo seguro para que los usuarios pudieran agregar notas (mensaje + imagen) a una transacción, validando previamente su identidad mediante un código OTP enviado al correo asociado a dicha transacción. Esto garantiza que solo usuarios legítimos puedan adjuntar información sensible.

Cambios realizados

Se agregó el endpoint POST /notes/request-access para solicitar el código OTP por transactionId.

Se agregó el endpoint POST /notes/verify-code para validar el código OTP recibido.

Se modificó el endpoint POST /notes/:transactionId para permitir crear una nota con mensaje e imagen opcional en formato base64 (subida a Cloudinary).

Se implementó un flujo de validación temporal con código OTP y token web para permitir el acceso seguro al último endpoint.

Se añadieron dos DTOs para estructurar las solicitudes en los nuevos endpoints.

El OTP y el token generado tienen una expiración de 5 minutos.

Impacto

Se mejora la seguridad al requerir validación previa (OTP) para crear notas.

Se habilita la carga de imágenes en base64, simplificando la integración desde el frontend.

Se evita el uso directo de URLs de imágenes.

Se garantiza que solo quienes validen su identidad puedan ejecutar la acción de crear notas.

Cómo probarlo

Enviar un POST a /notes/request-access con un transactionId válido.

Confirmar que el código OTP llega al correo del usuario asociado.

Validar el código enviando un POST a /notes/verify-code con el código y el transactionId.

Recibirás un token temporal si el OTP es correcto.

Con ese token, enviar un POST a /notes/:transactionId con un mensaje y una imagen en base64.

Verificar que la nota se guarde correctamente solo si el OTP fue validado y el token sigue vigente.