### PR TITLE
feat(notes): integración de validación OTP por transacción para creación de notas

### DIFF
--- a/src/modules/auth/entities/otp-code.entity.ts
+++ b/src/modules/auth/entities/otp-code.entity.ts
@@ -12,9 +12,12 @@ export class OtpCode {
   @PrimaryGeneratedColumn('uuid', { name: 'otp_code_id' })
   id: string;
 
-  @ManyToOne(() => User, (user) => user.otpCodes, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, (user) => user.otpCodes, { onDelete: 'CASCADE', nullable: true })
   @JoinColumn({ name: 'user_id' })
-  user: User;
+  user?: User;
+
+  @Column({ name: 'transaction_id', nullable: true })
+  transactionId?: string;
 
   @Column({ name: 'code' })
   code: string;
@@ -24,4 +27,7 @@ export class OtpCode {
 
   @Column({ name: 'is_used', default: false })
   isUsed: boolean;
+
+  @Column({ name: 'email', nullable: true })
+  email?: string; 
 }

--- a/src/modules/otp/otp.module.ts
+++ b/src/modules/otp/otp.module.ts
@@ -6,10 +6,11 @@ import { OtpController } from './otp.controller';
 import { OtpCode } from '@auth/entities/otp-code.entity';
 import { User } from '@users/entities/user.entity';
 import { AuthModule } from '@auth/auth.module';
+import { Transaction } from '@transactions/entities/transaction.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, OtpCode]),
+    TypeOrmModule.forFeature([User, OtpCode, Transaction]),
     MailerModule,
     AuthModule,
   ],

--- a/src/modules/transactions/entities/transaction.entity.ts
+++ b/src/modules/transactions/entities/transaction.entity.ts
@@ -63,9 +63,6 @@ export class Transaction {
   @JoinColumn({ name: 'receiver_account_id' })
   receiverAccount: ReceiverFinancialAccount;
 
-  @Column({ nullable: true, default: null })
-  userId: string;
-
   @OneToOne(() => Note, (note) => note.transaction)
   @JoinColumn({ name: 'note_id' })
   note: Note;


### PR DESCRIPTION
Resumen:
Se ha modificado el flujo del controlador de notas para utilizar los nuevos servicios OTP que validan transacciones mediante su ID, asegurando que solo usuarios asociados puedan generar notas.

Cambios principales:
- Endpoint requestAccess actualizado para enviar OTP usando sendOtpForTransaction(transactionId).
- Nuevo endpoint validateNote que valida el código OTP recibido con validateOtpForTransaction(transactionId, otpCode) y devuelve un token para crear la nota.
- Se cargan las relaciones necesarias de la transacción (senderAccount) para obtener correctamente el correo asociado.
- Manejo de errores para transacción no encontrada o correo inexistente.
- Actualización de pruebas y documentación de endpoints de notas.

Beneficios:
- Aumenta la seguridad y trazabilidad en la creación de notas.
- Garantiza que los códigos OTP se envíen únicamente a emails válidos vinculados a la transacción.