### PR TITLE
Fix/otp notas

### DIFF
--- a/src/modules/auth/entities/otp-code.entity.ts
+++ b/src/modules/auth/entities/otp-code.entity.ts
@@ -12,7 +12,10 @@ export class OtpCode {
   @PrimaryGeneratedColumn('uuid', { name: 'otp_code_id' })
   id: string;
 
-  @ManyToOne(() => User, (user) => user.otpCodes, { onDelete: 'CASCADE', nullable: true })
+  @ManyToOne(() => User, (user) => user.otpCodes, {
+    onDelete: 'CASCADE',
+    nullable: true,
+  })
   @JoinColumn({ name: 'user_id' })
   user?: User;
 
@@ -29,5 +32,5 @@ export class OtpCode {
   isUsed: boolean;
 
   @Column({ name: 'email', nullable: true })
-  email?: string; 
+  email?: string;
 }

--- a/src/modules/otp/otp.service.ts
+++ b/src/modules/otp/otp.service.ts
@@ -107,17 +107,26 @@ export class OtpService {
   }
 
   async validateOtpForTransaction(
-    transactionId: string,
+    email: string,
     code: string,
   ): Promise<boolean> {
+    // Buscar OTP por email y código
     const otp = await this.otpRepo.findOne({
-      where: { transactionId, code: code.trim(), isUsed: false },
+      where: { email, code, isUsed: false },
     });
-    if (!otp || otp.expiryDate < new Date()) {
+
+    // OTP no encontrado o ya usado'
+    if (!otp) {
       return false;
     }
+    // OTP expirado
+    if (otp.expiryDate < new Date()) {
+      return false;
+    }
+    // set OTP como usado para evitar reutilización
     otp.isUsed = true;
     await this.otpRepo.save(otp);
+
     return true;
   }
 

--- a/src/modules/otp/otp.service.ts
+++ b/src/modules/otp/otp.service.ts
@@ -57,37 +57,34 @@ export class OtpService {
     });
   }
 
-async sendOtpForTransaction(transactionId: string) {
-  // 1. Buscar la transacción con la relación senderAccount
-  const transaction = await this.transactionRepo.findOne({
-    where: { id: transactionId },
-    relations: ['senderAccount'], // <- aquí incluimos senderAccount
-  });
+  async sendOtpForTransaction(transactionId: string) {
+    // 1. Buscar la transacción con la relación senderAccount
+    const transaction = await this.transactionRepo.findOne({
+      where: { id: transactionId },
+      relations: ['senderAccount'], // <- aquí incluimos senderAccount
+    });
 
-  // 2. Validar que exista transacción y email del remitente
-  if (!transaction) {
-    throw new BadRequestException('Transacción no encontrada');
+    // 2. Validar que exista transacción y email del remitente
+    if (!transaction) {
+      throw new BadRequestException('Transacción no encontrada');
+    }
+    if (!transaction.senderAccount?.createdBy) {
+      throw new BadRequestException('Transacción sin email');
+    }
+
+    const email = transaction.senderAccount.createdBy;
+
+    // 3. Crear OTP
+    const otp = await this.createOtpForTransaction(transactionId, email);
+
+    // 4. Enviar correo
+    await this.mailer.sendAuthCodeMail(email, {
+      NAME: email,
+      VERIFICATION_CODE: otp.code,
+      BASE_URL: process.env.BASE_URL || 'https://swaplyar.com',
+      EXPIRATION_MINUTES: 5,
+    });
   }
-  if (!transaction.senderAccount?.createdBy) {
-    throw new BadRequestException('Transacción sin email');
-  }
-
-  const email = transaction.senderAccount.createdBy;
-
-  // 3. Crear OTP
-  const otp = await this.createOtpForTransaction(transactionId, email);
-
-  // 4. Enviar correo
-  await this.mailer.sendAuthCodeMail(email, {
-    NAME: email,
-    VERIFICATION_CODE: otp.code,
-    BASE_URL: process.env.BASE_URL || 'https://swaplyar.com',
-    EXPIRATION_MINUTES: 5,
-  });
-
-}
-
-
 
   async validateOtpAndGetUser(email: string, code: string): Promise<User> {
     const user = await this.userRepo.findOne({
@@ -109,17 +106,20 @@ async sendOtpForTransaction(transactionId: string) {
     return user;
   }
 
-  async validateOtpForTransaction(transactionId: string, code: string): Promise<boolean> {
-  const otp = await this.otpRepo.findOne({
-    where: { transactionId, code: code.trim(), isUsed: false },
-  });
-  if (!otp || otp.expiryDate < new Date()) {
-    return false;
+  async validateOtpForTransaction(
+    transactionId: string,
+    code: string,
+  ): Promise<boolean> {
+    const otp = await this.otpRepo.findOne({
+      where: { transactionId, code: code.trim(), isUsed: false },
+    });
+    if (!otp || otp.expiryDate < new Date()) {
+      return false;
+    }
+    otp.isUsed = true;
+    await this.otpRepo.save(otp);
+    return true;
   }
-  otp.isUsed = true;
-  await this.otpRepo.save(otp);
-  return true;
-}
 
   private async createOtpFor(user: User): Promise<OtpCode> {
     const code = generate(6, {
@@ -136,16 +136,23 @@ async sendOtpForTransaction(transactionId: string) {
     return this.otpRepo.save(otp);
   }
 
-  private async createOtpForTransaction(transactionId: string, email: string): Promise<OtpCode> {
-  const code = generate(6, { lowerCaseAlphabets: false, upperCaseAlphabets: false, specialChars: false }).trim();
-  const otp = this.otpRepo.create({
-    transactionId,
-    email,
-    code,
-    expiryDate: new Date(Date.now() + 10 * 60 * 1000), // 10 min
-  });
-  return this.otpRepo.save(otp);
-}
+  private async createOtpForTransaction(
+    transactionId: string,
+    email: string,
+  ): Promise<OtpCode> {
+    const code = generate(6, {
+      lowerCaseAlphabets: false,
+      upperCaseAlphabets: false,
+      specialChars: false,
+    }).trim();
+    const otp = this.otpRepo.create({
+      transactionId,
+      email,
+      code,
+      expiryDate: new Date(Date.now() + 10 * 60 * 1000), // 10 min
+    });
+    return this.otpRepo.save(otp);
+  }
 
   async generateAndSendOtp(user: User): Promise<void> {
     const otp = await this.createOtpFor(user);

--- a/src/modules/transactions/notes/notes.controller.ts
+++ b/src/modules/transactions/notes/notes.controller.ts
@@ -66,12 +66,10 @@ export class NotesController {
     const { transactionId } = dto;
     await this.otpService.sendOtpForTransaction(transactionId);
 
-  return {
-    message: 'Código enviado con éxito al correo asociado.',
-    code_sent: true,
-  };
-
-
+    return {
+      message: 'Código enviado con éxito al correo asociado.',
+      code_sent: true,
+    };
   }
 
   @ApiOperation({ summary: 'Verifica el código OTP para una transacción' })

--- a/src/modules/transactions/notes/notes.controller.ts
+++ b/src/modules/transactions/notes/notes.controller.ts
@@ -99,6 +99,8 @@ export class NotesController {
       },
     },
   })
+
+  // VERIFICA EL CODIGO OTP PARA UNA TRANSACCIÓN
   @Post('verify-code')
   async verifyNoteCode(@Body() dto: ValidateNoteCodeDto) {
     const transaction = await this.transactionsService.findOne(

--- a/src/modules/userAccounts/dto/create-bank-account.dto.ts
+++ b/src/modules/userAccounts/dto/create-bank-account.dto.ts
@@ -65,8 +65,8 @@ export class UserAccValuesDto {
 
   // pix
   @IsOptional()
-  @IsNumber()
-  cpf: number;
+  @IsString()
+  cpf: string;
   @IsOptional()
   @IsString()
   pix_value: string;

--- a/src/modules/userAccounts/entities/user-pix.entity.ts
+++ b/src/modules/userAccounts/entities/user-pix.entity.ts
@@ -18,8 +18,8 @@ export class UserPix {
   @Column({ name: 'pix_value' })
   pix_value: string;
 
-  @Column()
-  cpf: number;
+  @Column({ type: 'char', length: 11 })
+  cpf: string;
 
   // 👇 agregamos la FK como propiedad explícita
   @Column({ name: 'account_id' })

--- a/src/modules/userAccounts/userAccounts.controller.ts
+++ b/src/modules/userAccounts/userAccounts.controller.ts
@@ -106,7 +106,6 @@ export class AccountsController {
   }
 
   //DELETE una cuenta de banco
-
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('user')
   @Delete()

--- a/src/modules/userAccounts/userAccounts.controller.ts
+++ b/src/modules/userAccounts/userAccounts.controller.ts
@@ -90,7 +90,7 @@ export class AccountsController {
     },
   })
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('user')
+  /*   @Roles('user') */
   @Post()
   @HttpCode(HttpStatus.CREATED)
   async create(@Request() req, @Body() dto: CreateBankAccountDto) {
@@ -140,14 +140,14 @@ export class AccountsController {
       ],
     },
   })
+  // Obtener todas las cuentas de banco de un user
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('user')
+  /*   @Roles('user') */
   @Get()
   async findAll(@Request() req) {
     return this.accountsService.findAllBanks(req.user.id);
   }
 
-  // Obtener todas las cuentas de banco de un user
   @ApiOperation({
     summary: 'Obtener todas las cuentas del usuario autenticado',
   })

--- a/src/modules/userAccounts/userAccounts.controller.ts
+++ b/src/modules/userAccounts/userAccounts.controller.ts
@@ -95,7 +95,6 @@ export class AccountsController {
   @HttpCode(HttpStatus.CREATED)
   async create(@Request() req, @Body() dto: CreateBankAccountDto) {
     const userId = req.user.id;
-    console.log('user');
 
     const newBank = await this.accountsService.createUserBan(
       dto.userAccValues.accountType,

--- a/src/modules/userAccounts/userAccounts.service.ts
+++ b/src/modules/userAccounts/userAccounts.service.ts
@@ -34,7 +34,7 @@ export class AccountsService {
   ) {}
 
   async createUserBan(
-    accountType: any,
+    accountType: Platform,
     userAccValues: UserAccValuesDto,
     userId: string,
   ) {
@@ -49,6 +49,7 @@ export class AccountsService {
       // busca un tipo de cuenta para poder registrarla en una tabla
       // ejemplo: si es igual a virtual_bank la busca en la tabla y crea una nueva
       let specificAccount;
+      console.log('accountType', accountType);
 
       // crea una cuenta de banco
       if (accountType === Platform.Bank) {

--- a/src/modules/userAccounts/userAccounts.service.ts
+++ b/src/modules/userAccounts/userAccounts.service.ts
@@ -49,7 +49,6 @@ export class AccountsService {
       // busca un tipo de cuenta para poder registrarla en una tabla
       // ejemplo: si es igual a virtual_bank la busca en la tabla y crea una nueva
       let specificAccount;
-      console.log('accountType', accountType);
 
       // crea una cuenta de banco
       if (accountType === Platform.Bank) {

--- a/src/modules/users/verification/user-verification.service.ts
+++ b/src/modules/users/verification/user-verification.service.ts
@@ -59,23 +59,17 @@ export class UserVerificationService {
     });
 
     if (existingVerification) {
-
       return {
-
         success: true,
         message:
           'Ya existe una solicitud pendiente. Puede reintentar sin problemas.',
 
         data: {
-
           verification_id: existingVerification.verification_id,
           verification_status: existingVerification.verification_status,
-
         },
-
       };
-
-   }
+    }
 
     const folder = 'SwaplyAr/admin/user_verification';
 
@@ -106,29 +100,26 @@ export class UserVerificationService {
       verification_status: VerificationStatus.PENDING,
     });
 
-    const savedVerification = await this.userVerificationRepository.save(verification);
+    const savedVerification =
+      await this.userVerificationRepository.save(verification);
 
     return {
-
       success: true,
-      message: 'Imágenes de verificación subidas correctamente. Su verificación está pendiente de revisión.',
+      message:
+        'Imágenes de verificación subidas correctamente. Su verificación está pendiente de revisión.',
 
       data: {
-
         verification_id: savedVerification.verification_id,
         verification_status: savedVerification.verification_status,
-
       },
-
     };
-
   }
 
   async findByUserId(userId: string): Promise<UserVerification> {
     const verification = await this.userVerificationRepository.findOne({
       where: { user: { id: userId } },
       order: { created_at: 'DESC' },
-      });
+    });
 
     if (!verification) {
       throw new NotFoundException(


### PR DESCRIPTION

1- Se cambio la propiedad cpf de number a string en la entidad user_pix.

2- Se arreglo la validacion del codigo otp de cuando se envia una nota:
`POST /api/v2/notes/verify-code`
ahora solamente si el usuario intenta ingresar con un codigo que no es el enviado al correo o envia dos veces el mismo codigo mostrara un mensaje de error 

anteriormente con cualquier codigo mostraba todas las notas y se podia repetir.

