### PR TITLE
Feature/refact banks

### DIFF
--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -38,7 +38,10 @@ import { User as UserEntity } from '@users/entities/user.entity';
 import { StatusHistoryResponse } from 'src/common/interfaces/status-history.interface';
 import { MailerService } from '../mailer/mailer.service';
 import { Transaction } from 'typeorm';
-import { TransactionAdminResponseDto, TransactionByIdAdminResponseDto } from './dto/get-transaction-response.dto';
+import {
+  TransactionAdminResponseDto,
+  TransactionByIdAdminResponseDto,
+} from './dto/get-transaction-response.dto';
 import { RolesGuard } from '@common/guards/roles.guard';
 import { Roles } from '@common/decorators/roles.decorator';
 
@@ -53,16 +56,35 @@ export class AdminController {
   ) {}
 
   @ApiOperation({ summary: 'Obtener todas las transacciones' })
-  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Número de página (por defecto 1)' })
-  @ApiQuery({ name: 'perPage', required: false, type: Number, description: 'Cantidad de elementos por página (por defecto 10)' })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Número de página (por defecto 1)',
+  })
+  @ApiQuery({
+    name: 'perPage',
+    required: false,
+    type: Number,
+    description: 'Cantidad de elementos por página (por defecto 10)',
+  })
   @ApiResponse({
     status: 200,
     description: 'Transacciones obtenidas correctamente',
     type: TransactionAdminResponseDto,
   })
-  @ApiResponse({ status: 401, description: '❌ No autorizado. Token no válido o no enviado.' })
-  @ApiResponse({ status: 403, description: '❌ Acceso no autorizado, Solo para Administradores' })
-  @ApiResponse({ status: 404, description: '❌ No se encuentran Transacciones' })
+  @ApiResponse({
+    status: 401,
+    description: '❌ No autorizado. Token no válido o no enviado.',
+  })
+  @ApiResponse({
+    status: 403,
+    description: '❌ Acceso no autorizado, Solo para Administradores',
+  })
+  @ApiResponse({
+    status: 404,
+    description: '❌ No se encuentran Transacciones',
+  })
   @ApiResponse({ status: 500, description: '❌ Error interno del servidor' })
   @Get('transactions')
   async getAllTransactions(
@@ -75,13 +97,15 @@ export class AdminController {
   @ApiOperation({ summary: 'Agregar comprobante a una transacción' })
   @ApiConsumes('multipart/form-data')
   @ApiBody({
-    description: 'Sube un comprobante para una transacción. El `transactionId` es obligatorio y el `comprobante` es el archivo.',
+    description:
+      'Sube un comprobante para una transacción. El `transactionId` es obligatorio y el `comprobante` es el archivo.',
     schema: {
       type: 'object',
       properties: {
         transactionId: {
           type: 'string',
-          description: 'ID de la transacción a la que se asocia el comprobante.',
+          description:
+            'ID de la transacción a la que se asocia el comprobante.',
         },
         comprobante: {
           type: 'string',
@@ -156,7 +180,9 @@ export class AdminController {
   }
 
   @Get('transactions/status')
-  @ApiOperation({ summary: 'Obtener historial completo de estados de todas las transacciones' })
+  @ApiOperation({
+    summary: 'Obtener historial completo de estados de todas las transacciones',
+  })
   @ApiQuery({ name: 'page', required: false, type: Number })
   @ApiQuery({ name: 'limit', required: false, type: Number })
   @ApiResponse({
@@ -232,7 +258,8 @@ export class AdminController {
             motivo: 'Verificación completa',
             notas: 'Sin observaciones',
           },
-          description: 'Datos adicionales que pueden acompañar el cambio de estado',
+          description:
+            'Datos adicionales que pueden acompañar el cambio de estado',
         },
       },
       required: ['status'],
@@ -268,37 +295,46 @@ export class AdminController {
     description: 'Transacción encontrada',
     type: TransactionByIdAdminResponseDto,
   })
-    @ApiResponse({ status: 401, description: '❌ No autorizado. Token no válido o no enviado.' })
-  @ApiResponse({ status: 403, description: '❌ Acceso no autorizado, Solo para Administradores' })
+  @ApiResponse({
+    status: 401,
+    description: '❌ No autorizado. Token no válido o no enviado.',
+  })
+  @ApiResponse({
+    status: 403,
+    description: '❌ Acceso no autorizado, Solo para Administradores',
+  })
   @ApiResponse({ status: 404, description: '❌ Transaccion no Encontrada' })
   @ApiResponse({ status: 500, description: '❌ Error interno del servidor' })
-  @ApiParam({ name: 'id', description: 'ID de la transacción', example: 'uuid' })
+  @ApiParam({
+    name: 'id',
+    description: 'ID de la transacción',
+    example: 'uuid',
+  })
   @Get('transactions/:id')
   async getTransaction(
-  @Param('id') id: string,
-): Promise<{ data?: TransactionByIdAdminResponseDto; message?: string }> {
-  try {
-    if (!id) {
-      return {
-        message: 'El ID de la transacción es requerido.',
-      };
-    }
+    @Param('id') id: string,
+  ): Promise<{ data?: TransactionByIdAdminResponseDto; message?: string }> {
+    try {
+      if (!id) {
+        return {
+          message: 'El ID de la transacción es requerido.',
+        };
+      }
 
-    const transaction = await this.adminService.getTransactionById(id);
+      const transaction = await this.adminService.getTransactionById(id);
 
-    return {
-      data: this.adminService.formatTransaction(transaction),
-    };
-  } catch (error) {
-    if (error instanceof NotFoundException) {
       return {
-        message: 'Transacción no encontrada.',
+        data: this.adminService.formatTransaction(transaction),
       };
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        return {
+          message: 'Transacción no encontrada.',
+        };
+      }
+      throw error;
     }
-    throw error;
   }
-}
-
 
   @ApiOperation({ summary: 'Actualizar el estado de una transacción por tipo' })
   @ApiResponse({

--- a/src/modules/admin/admin.service.ts
+++ b/src/modules/admin/admin.service.ts
@@ -21,7 +21,10 @@ import { StatusHistoryResponse } from 'src/common/interfaces/status-history.inte
 import { DiscountService } from '@discounts/discounts.service';
 import { UpdateStarDto } from '@discounts/dto/update-star.dto';
 import { TransactionGetResponseDto } from '@transactions/dto/transaction-response.dto';
-import { TransactionAdminResponseDto, TransactionByIdAdminResponseDto } from './dto/get-transaction-response.dto';
+import {
+  TransactionAdminResponseDto,
+  TransactionByIdAdminResponseDto,
+} from './dto/get-transaction-response.dto';
 
 @Injectable()
 export class AdminService {
@@ -40,7 +43,7 @@ export class AdminService {
     private readonly discountService: DiscountService,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
-  ) { }
+  ) {}
 
   private convertAdminStatusToTransactionStatus(
     status: AdminStatus,
@@ -66,75 +69,72 @@ export class AdminService {
   /* -------------------------------------------------------------------------- */
   /*                                 FIND ALL                                   */
   /* -------------------------------------------------------------------------- */
-async findAllTransactions(
-  page: number = 1,
-  perPage: number = 10,
-): Promise<{ meta: any; data: TransactionAdminResponseDto[] }> {
-  const [transactions, total] = await this.transactionsRepository.findAndCount({
-    relations: [
-      'senderAccount',
-      'senderAccount.paymentMethod',
-      'receiverAccount',
-      'receiverAccount.paymentMethod',
-      'amount',
-      'proofOfPayment',
-      'note',
-    ],
-    skip: (page - 1) * perPage,
-    take: perPage,
-  });
+  async findAllTransactions(
+    page: number = 1,
+    perPage: number = 10,
+  ): Promise<{ meta: any; data: TransactionAdminResponseDto[] }> {
+    const [transactions, total] =
+      await this.transactionsRepository.findAndCount({
+        relations: [
+          'senderAccount',
+          'senderAccount.paymentMethod',
+          'receiverAccount',
+          'receiverAccount.paymentMethod',
+          'amount',
+          'proofOfPayment',
+          'note',
+        ],
+        skip: (page - 1) * perPage,
+        take: perPage,
+      });
 
-  const data = transactions.map(tx => ({
-    id: tx.id,
-    countryTransaction: tx.countryTransaction,
-    message: tx.message,
-    createdAt: tx.createdAt.toISOString(),
-    finalStatus: tx.finalStatus,
-    senderAccount: {
-      id: tx.senderAccount.id,
-      firstName: tx.senderAccount.firstName,
-      lastName: tx.senderAccount.lastName,
-      createdBy: tx.senderAccount.createdBy,
-      phoneNumber: tx.senderAccount.phoneNumber,
-      paymentMethod: {
-        id: tx.senderAccount.paymentMethod.id,
-        platformId: tx.senderAccount.paymentMethod.platformId,
-        method: tx.senderAccount.paymentMethod.method,
+    const data = transactions.map((tx) => ({
+      id: tx.id,
+      countryTransaction: tx.countryTransaction,
+      message: tx.message,
+      createdAt: tx.createdAt.toISOString(),
+      finalStatus: tx.finalStatus,
+      senderAccount: {
+        id: tx.senderAccount.id,
+        firstName: tx.senderAccount.firstName,
+        lastName: tx.senderAccount.lastName,
+        createdBy: tx.senderAccount.createdBy,
+        phoneNumber: tx.senderAccount.phoneNumber,
+        paymentMethod: {
+          id: tx.senderAccount.paymentMethod.id,
+          platformId: tx.senderAccount.paymentMethod.platformId,
+          method: tx.senderAccount.paymentMethod.method,
+        },
       },
-    },
-    receiverAccount: {
-      id: tx.receiverAccount.id,
-      paymentMethod: tx.receiverAccount.paymentMethod,
-    },
-    note: tx.note && { note_id: tx.note.note_id },
-    proofOfPayment: tx.proofOfPayment,
-    amount: tx.amount,
-    isNoteVerified: tx.isNoteVerified,
-    noteVerificationExpiresAt: tx.noteVerificationExpiresAt
-      ? tx.noteVerificationExpiresAt.toISOString()
-      : '',
-  }));
+      receiverAccount: {
+        id: tx.receiverAccount.id,
+        paymentMethod: tx.receiverAccount.paymentMethod,
+      },
+      note: tx.note && { note_id: tx.note.note_id },
+      proofOfPayment: tx.proofOfPayment,
+      amount: tx.amount,
+      isNoteVerified: tx.isNoteVerified,
+      noteVerificationExpiresAt: tx.noteVerificationExpiresAt
+        ? tx.noteVerificationExpiresAt.toISOString()
+        : '',
+    }));
 
-  return {
-    meta: {
-      totalPages: Math.ceil(total / perPage),
-      page,
-      perPage,
-      totalTransactions: total,
-    },
-    data,
-  };
-}
-
+    return {
+      meta: {
+        totalPages: Math.ceil(total / perPage),
+        page,
+        perPage,
+        totalTransactions: total,
+      },
+      data,
+    };
+  }
 
   /* -------------------------------------------------------------------------- */
   /*                         GET TRANSACTION BY ID                              */
   /* -------------------------------------------------------------------------- */
 
-
-
-  
-async getTransactionById(id: string): Promise<Transaction> {
+  async getTransactionById(id: string): Promise<Transaction> {
     const transaction = await this.transactionsRepository.findOne({
       where: { id },
       relations: [
@@ -157,69 +157,70 @@ async getTransactionById(id: string): Promise<Transaction> {
     return transaction; // sin map ni filtrado
   }
 
-private removeNulls(obj: any): any {
-  if (obj === null || obj === undefined) return undefined;
+  private removeNulls(obj: any): any {
+    if (obj === null || obj === undefined) return undefined;
 
-  if (Array.isArray(obj)) {
-    return obj.map(this.removeNulls).filter(v => v !== undefined);
+    if (Array.isArray(obj)) {
+      return obj.map(this.removeNulls).filter((v) => v !== undefined);
+    }
+
+    if (typeof obj === 'object') {
+      const newObj: any = {};
+      Object.keys(obj).forEach((key) => {
+        const value = this.removeNulls(obj[key]);
+        if (value !== undefined) {
+          newObj[key] = value;
+        }
+      });
+      return Object.keys(newObj).length ? newObj : undefined;
+    }
+
+    return obj;
   }
 
-  if (typeof obj === 'object') {
-    const newObj: any = {};
-    Object.keys(obj).forEach(key => {
-      const value = this.removeNulls(obj[key]);
-      if (value !== undefined) {
-        newObj[key] = value;
-      }
-    });
-    return Object.keys(newObj).length ? newObj : undefined;
+  formatTransaction(transaction: Transaction): TransactionByIdAdminResponseDto {
+    // ⬅️ Corregido el tipo de entrada
+    const sender = transaction.senderAccount;
+    const receiver = transaction.receiverAccount;
+
+    // Manejo de la nota para evitar errores de 'undefined' y convertir la fecha
+    const formattedNote = transaction.note
+      ? {
+          note_id: transaction.note.note_id,
+          img_url: transaction.note.img_url,
+          message: transaction.note.message,
+          // Convertimos la fecha (tipo Date) a string ISO, si existe.
+          createdAt: transaction.note.createdAt?.toISOString(),
+        }
+      : null; // Si no hay nota, el campo es nulo.
+
+    // Construimos el objeto final con todos los campos necesarios.
+    return {
+      id: transaction.id,
+      countryTransaction: transaction.countryTransaction,
+      message: transaction.message,
+      createdAt: transaction.createdAt.toISOString(),
+      finalStatus: transaction.finalStatus,
+      senderAccount: this.removeNulls({
+        id: sender.id,
+        firstName: sender.firstName,
+        lastName: sender.lastName,
+        createdBy: sender.createdBy,
+        phoneNumber: sender.phoneNumber,
+        paymentMethod: sender.paymentMethod,
+      }),
+      receiverAccount: {
+        id: receiver.id,
+        paymentMethod: receiver.paymentMethod, // Igual que arriba
+      },
+      note: formattedNote, // Usamos el objeto de nota formateado
+      proofOfPayment: transaction.proofOfPayment,
+      amount: transaction.amount,
+      isNoteVerified: transaction.isNoteVerified,
+      noteVerificationExpiresAt:
+        transaction.noteVerificationExpiresAt?.toISOString(),
+    } as TransactionByIdAdminResponseDto;
   }
-
-  return obj;
-}
-
-
-formatTransaction(transaction: Transaction): TransactionByIdAdminResponseDto { // ⬅️ Corregido el tipo de entrada
-  const sender = transaction.senderAccount;
-  const receiver = transaction.receiverAccount;
-
-  // Manejo de la nota para evitar errores de 'undefined' y convertir la fecha
-  const formattedNote = transaction.note
-    ? {
-        note_id: transaction.note.note_id,
-        img_url: transaction.note.img_url,
-        message: transaction.note.message,
-        // Convertimos la fecha (tipo Date) a string ISO, si existe.
-        createdAt: transaction.note.createdAt?.toISOString(), 
-      }
-    : null; // Si no hay nota, el campo es nulo.
-
-  // Construimos el objeto final con todos los campos necesarios.
-  return {
-    id: transaction.id,
-    countryTransaction: transaction.countryTransaction,
-    message: transaction.message,
-    createdAt: transaction.createdAt.toISOString(),
-    finalStatus: transaction.finalStatus,
-    senderAccount: this.removeNulls({
-      id: sender.id,
-      firstName: sender.firstName,
-      lastName: sender.lastName,
-      createdBy: sender.createdBy,
-      phoneNumber: sender.phoneNumber,
-      paymentMethod: sender.paymentMethod,
-    }),
-    receiverAccount: {
-      id: receiver.id,
-      paymentMethod: receiver.paymentMethod, // Igual que arriba
-    },
-    note: formattedNote, // Usamos el objeto de nota formateado
-    proofOfPayment: transaction.proofOfPayment,
-    amount: transaction.amount,
-    isNoteVerified: transaction.isNoteVerified,
-    noteVerificationExpiresAt: transaction.noteVerificationExpiresAt?.toISOString(),
-  } as TransactionByIdAdminResponseDto;
-}
   /* -------------------------------------------------------------------------- */
   /*                        STATUS HISTORY FOR A TX                              */
   /* -------------------------------------------------------------------------- */
@@ -356,7 +357,8 @@ formatTransaction(transaction: Transaction): TransactionByIdAdminResponseDto { /
     if (status === AdminStatus.Approved) {
       // Solo cambia el estado, no asigna recompensas
       return {
-        message: 'Estado cambiado a approved correctamente. No se asignaron recompensas.',
+        message:
+          'Estado cambiado a approved correctamente. No se asignaron recompensas.',
         status: 200,
         transaction: updatedTransaction,
       };

--- a/src/modules/otp/otp.service.ts
+++ b/src/modules/otp/otp.service.ts
@@ -10,7 +10,7 @@ import { User } from '@users/entities/user.entity';
 import { MailerService } from '@mailer/mailer.service';
 import { generate } from 'otp-generator';
 import * as jwt from 'jsonwebtoken';
-import { ConfigService } from '@nestjs/config';
+
 import { Transaction } from '@transactions/entities/transaction.entity';
 
 @Injectable()
@@ -29,14 +29,12 @@ export class OtpService {
     private readonly otpRepo: Repository<OtpCode>,
 
     private readonly mailer: MailerService,
-
-    private readonly configService: ConfigService,
   ) {
-    this.secret = this.configService.get<string>(
-      'otp.jwtSecret',
-      'supersecret',
-    );
-    this.ttlSeconds = this.configService.get<number>('otp.ttl', 300);
+    if (!process.env.JWT_SECRET) {
+      throw new Error('JWT_SECRET environment variable is not defined');
+    }
+    this.secret = process.env.JWT_SECRET;
+    this.ttlSeconds = 16000;
   }
 
   async sendOtpToEmail(email: string): Promise<void> {
@@ -115,7 +113,7 @@ export class OtpService {
       where: { email, code, isUsed: false },
     });
 
-    // OTP no encontrado o ya usado'
+    // OTP no encontrado o ya usado
     if (!otp) {
       return false;
     }
@@ -185,12 +183,18 @@ export class OtpService {
     iat?: number;
     exp?: number;
   } {
+    console.log(this.secret);
     try {
-      return jwt.verify(token, this.secret) as {
+      console.log(this.secret);
+      const payload = jwt.verify(token, this.secret) as {
         transactionId: string;
         iat?: number;
         exp?: number;
       };
+
+      console.log('Payload del token verificado:', payload);
+
+      return payload;
     } catch {
       throw new UnauthorizedException('OTP inválido o expirado');
     }

--- a/src/modules/transactions/notes/dto/create-note.dto.ts
+++ b/src/modules/transactions/notes/dto/create-note.dto.ts
@@ -1,11 +1,7 @@
-import { IsString } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateNoteDto {
-  @IsString()
-  @ApiProperty({
-    description: 'Mensaje asociado a la transacción',
-    example: 'Pago recibido correctamente',
-  })
+  @IsString({ message: 'El campo "message" debe ser un texto' })
+  @IsNotEmpty({ message: 'El campo "message" es obligatorio' })
   message: string;
 }

--- a/src/modules/transactions/notes/notes.controller.ts
+++ b/src/modules/transactions/notes/notes.controller.ts
@@ -31,6 +31,8 @@ import { ValidateNoteCodeDto } from './dto/validate-note-code.dto';
 import { RequestNoteCodeDto } from './dto/request-note-code.dto';
 import { CreateNoteDto } from './dto/create-note.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
 
 @ApiTags('Notas')
 @Controller('notes')
@@ -191,14 +193,19 @@ export class NotesController {
     description: 'Token temporal devuelto por /notes/verify-code',
     required: true,
   })
+  // crea una nota
   @Post(':transactionId')
   async create(
     @Param('transactionId') transactionId: string,
     @UploadedFile() file: Express.Multer.File,
-    @Body() createNoteDto: CreateNoteDto,
+    @Body() createNoteDto: any,
     @Req() req: Request,
   ) {
     const token = req.headers['note-access-token'] as string;
+    console.log('TOKEN:', token);
+    console.log('TRANSACTION ID:', transactionId);
+    console.log('body:', createNoteDto);
+
     if (!token)
       throw new BadRequestException('Falta el header note-access-token');
 

--- a/src/modules/transactions/notes/notes.service.ts
+++ b/src/modules/transactions/notes/notes.service.ts
@@ -34,80 +34,90 @@ export class NotesService {
   }
 
   async create(
-  transactionId: string,
-  createNoteDto: CreateNoteDto,
-  token: string,
-  file?: Express.Multer.File,
-) {
-  let payload: { transactionId: string };
-
-  try {
-    payload = this.otpService.verifyOtpToken(token);
-  } catch (err) {
-    throw new BadRequestException('Token inválido o expirado');
-  }
-
-  if (payload.transactionId !== transactionId) {
-    throw new BadRequestException(
-      'El token no corresponde a esta transacción',
-    );
-  }
-
-  const transaction = await this.transactionRepository.findOne({
-    where: { id: transactionId },
-  });
-
-  if (!transaction) {
-    throw new NotFoundException('Transacción no encontrada');
-  }
-  if (transaction.note) {
-  throw new BadRequestException(
-    'Esta transacción ya tiene una nota asociada',
-  );
-}
-  if (
-    !transaction.isNoteVerified ||
-    !transaction.noteVerificationExpiresAt ||
-    new Date() > transaction.noteVerificationExpiresAt
+    transactionId: string,
+    createNoteDto: CreateNoteDto,
+    token: string,
+    file?: Express.Multer.File,
   ) {
-    throw new NotFoundException(
-      'El acceso para crear nota ha expirado o no está habilitado',
-    );
-  }
-
-  let img_url: string | undefined;
-
-  if (file) {
+    // Verificar token OTP
+    let payload: { transactionId: string };
     try {
-      img_url = await this.cloudinaryService.uploadFile(
-        file.buffer,
-        'notes',
-        `note-${Date.now()}`,
-      );
-    } catch (error) {
+      payload = this.otpService.verifyOtpToken(token);
+    } catch (err) {
+      throw new BadRequestException('Token inválido o expirado');
+    }
+
+    if (payload.transactionId !== transactionId) {
       throw new BadRequestException(
-        'Error al subir la imagen a Cloudinary: ' + error.message,
+        'El token no corresponde a esta transacción',
       );
     }
+
+    // Obtener transacción y relacion note
+    const transaction = await this.transactionRepository.findOne({
+      where: { id: transactionId },
+      relations: ['note'], // importante para chequear si ya existe
+    });
+
+    if (!transaction) {
+      throw new NotFoundException('Transacción no encontrada');
+    }
+
+    //  Evitar duplicados
+    if (transaction.note) {
+      throw new BadRequestException(
+        'Ya existe una nota creada para esta transacción',
+      );
+    }
+
+    //  Validar message obligatorio
+    if (!createNoteDto.message || createNoteDto.message.trim() === '') {
+      throw new BadRequestException('El campo message es obligatorio');
+    }
+
+    //  Verificar que la nota esté habilitada
+    if (
+      !transaction.isNoteVerified ||
+      !transaction.noteVerificationExpiresAt ||
+      new Date() > transaction.noteVerificationExpiresAt
+    ) {
+      throw new NotFoundException(
+        'El acceso para crear nota ha expirado o no está habilitado',
+      );
+    }
+
+    //  Subir imagen a Cloudinary si existe
+    let img_url: string | undefined;
+    if (file) {
+      try {
+        img_url = await this.cloudinaryService.uploadFile(
+          file.buffer,
+          'notes',
+          `note-${Date.now()}`,
+        );
+      } catch (error) {
+        throw new BadRequestException(
+          'Error al subir la imagen a Cloudinary: ' + error.message,
+        );
+      }
+    }
+
+    // Crear nota
+    const note = this.notesRepository.create({
+      ...createNoteDto,
+      transaction,
+      img_url,
+    });
+
+    //  Guardar nota
+    const savedNote = await this.notesRepository.save(note);
+
+    //  Asociar la nota a la transacción y guardar
+    transaction.note = savedNote;
+    await this.transactionRepository.save(transaction);
+
+    return savedNote;
   }
-
-  // Crear nota
-  const note = this.notesRepository.create({
-    ...createNoteDto,
-    transaction,
-    img_url,
-  });
-
-  // Guardar nota
-  const savedNote = await this.notesRepository.save(note);
-
-  // Asociar la nota a la transacción y guardar la transacción
-  transaction.note = savedNote;
-  await this.transactionRepository.save(transaction);
-
-  return savedNote;
-}
-
 
   async findAll() {
     const notes = await this.notesRepository.find();

--- a/src/modules/transactions/transactions.controller.ts
+++ b/src/modules/transactions/transactions.controller.ts
@@ -377,27 +377,27 @@ export class TransactionsController {
   })
   @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
   @ApiQuery({ name: 'pageSize', required: false, type: Number, example: 10 })
-async findAll(
-  @Req() req: RequestWithUser,
-  @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
-  @Query('pageSize', new DefaultValuePipe(10), ParseIntPipe) pageSize: number,
-): Promise<{
-  data: TransactionGetResponseDto[];
-  pagination: {
-    page: number;
-    pageSize: number;
-    totalItems: number;
-    totalPages: number;
-  };
-}> {
-  const email = req.user.email;
+  async findAll(
+    @Req() req: RequestWithUser,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('pageSize', new DefaultValuePipe(10), ParseIntPipe) pageSize: number,
+  ): Promise<{
+    data: TransactionGetResponseDto[];
+    pagination: {
+      page: number;
+      pageSize: number;
+      totalItems: number;
+      totalPages: number;
+    };
+  }> {
+    const email = req.user.email;
 
-  return await this.transactionsService.findAllUserEmail(
-    email,
-    page,
-    pageSize,
-  );
-}
+    return await this.transactionsService.findAllUserEmail(
+      email,
+      page,
+      pageSize,
+    );
+  }
 
   // Obtener transacción por ID con autorización
   @Get(':transaction_id')
@@ -418,8 +418,8 @@ async findAll(
     type: TransactionGetByIdDto,
   })
   @ApiUnauthorizedResponse({
-      description: 'No autorizado. Token no válido o no enviado.',
-    })
+    description: 'No autorizado. Token no válido o no enviado.',
+  })
   @ApiResponse({
     status: 403,
     description: '❌ Acceso no autorizado a la transacción',
@@ -432,7 +432,7 @@ async findAll(
     status: 500,
     description: '⚠️ Error interno del servidor',
   })
-     @Get(':transaction_id')
+  @Get(':transaction_id')
   async getTransactionByEmail(
     @Param('transaction_id') transactionId: string,
     @Request() req: RequestWithUser,
@@ -440,10 +440,11 @@ async findAll(
     const userEmail = req.user.email;
 
     try {
-      const transaction: Transaction = await this.transactionsService.getTransactionByEmail(
-        transactionId,
-        userEmail,
-      );
+      const transaction: Transaction =
+        await this.transactionsService.getTransactionByEmail(
+          transactionId,
+          userEmail,
+        );
 
       // Convierte Transaction → TransactionGetByIdDto y elimina los nulls automáticamente
       const dto = plainToInstance(TransactionGetByIdDto, transaction, {
@@ -456,10 +457,13 @@ async findAll(
         throw new ForbiddenException(error.message || 'Acceso no autorizado');
       }
       if (error instanceof NotFoundException) {
-        throw new NotFoundException(error.message || 'Transacción no encontrada');
+        throw new NotFoundException(
+          error.message || 'Transacción no encontrada',
+        );
       }
-      throw new InternalServerErrorException('Error inesperado al obtener la transacción');
+      throw new InternalServerErrorException(
+        'Error inesperado al obtener la transacción',
+      );
     }
   }
-
 }


### PR DESCRIPTION
### **1- Mejora en los mensajes de error de notas**
Antes se devolvía un código genérico 500. Ahora se envían mensajes y códigos personalizados según el caso:

Ejemplos:

```
{ "message": "Ya existe una nota creada para esta transacción" }
{ "message": "Debes verificar el código para esta transacción" }
```


### **2-  Uso de secret desde .env en OTP**
Se eliminó el JWT_SECRET hardcodeado en verifyOtpToken y ahora se utiliza el valor configurado en el archivo .env.