### PR TITLE
feat(transactions): agregar soporte de regret en transacciones

### DIFF
--- a/src/modules/transactions/dto/transaction-response.dto.ts
+++ b/src/modules/transactions/dto/transaction-response.dto.ts
@@ -1,4 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { RegretDto } from '@transactions/regrets/dto/regret-response-dto';
+import { Regret } from '@transactions/regrets/entities/regrets.entity';
 import { Expose, Type } from 'class-transformer';
 import { IsEmail, IsOptional, IsString } from 'class-validator';
 
@@ -188,6 +190,16 @@ export class TransactionResponseDto {
   @Expose()
   @ApiProperty({ name: 'finalStatus', example: 'pending' })
   finalStatus: string;
+
+  @Expose()
+  @Type(() => RegretDto)
+  @ApiProperty({ type: RegretDto, required: false })
+  regret?: RegretDto;
+
+  @Expose()
+  @ApiProperty({ example: null })
+  regretId?: string | null;
+
 
   @Expose()
   @Type(() => AccountSenderDto)
@@ -418,6 +430,9 @@ export class TransactionGetResponseDto {
 
   @ApiProperty({ example: 'pending' })
   finalStatus: string;
+
+  @ApiProperty({ example: 'c7a0e81d-2a49-4d09-8120-6f02d63e1f01', nullable: true })
+  regretId?: string | null;
 
   @ApiProperty({ type: SenderAccountDto })
   senderAccount: SenderAccountDto;

--- a/src/modules/transactions/regrets/dto/regret-response-dto.ts
+++ b/src/modules/transactions/regrets/dto/regret-response-dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Expose } from "class-transformer";
+
+export class RegretDto {
+  @Expose()
+  @ApiProperty({ example: '375c0ae0-6f94-47f9-9585-a7bfa4f5f57c' })
+  id: string;
+
+  @Expose()
+  @ApiProperty({ example: 'Pérez' })
+  lastName: string;
+
+  @Expose()
+  @ApiProperty({ example: '+12456789' })
+  phoneNumber: string;
+
+  @Expose()
+  @ApiProperty({ example: 'Descripción de prueba' })
+  description: string;
+}

--- a/src/modules/transactions/regrets/regrets.service.ts
+++ b/src/modules/transactions/regrets/regrets.service.ts
@@ -49,7 +49,12 @@ export class RegretsService {
     }
 
     const regret = this.regretsRepository.create(createRegretDto);
-    return await this.regretsRepository.save(regret);
+    const savedRegret = await this.regretsRepository.save(regret);
+
+    transaction.regret = savedRegret;
+    await this.transactionRepository.save(transaction);
+
+    return savedRegret;
   }
 
   findAll() {

--- a/src/modules/transactions/transactions.service.ts
+++ b/src/modules/transactions/transactions.service.ts
@@ -258,6 +258,7 @@ export class TransactionsService {
         receiverAccount: { paymentMethod: true },
         proofOfPayment: true,
         amount: true,
+        regret: true,
       },
       where: { senderAccount: { createdBy } },
       skip,
@@ -323,6 +324,7 @@ export class TransactionsService {
         id: tx.id,
         createdAt: tx.createdAt.toISOString(),
         finalStatus: tx.finalStatus,
+        regretId: tx.regret ? tx.regret.id : null,
         senderAccount: {
           id: tx.senderAccount.id,
           firstName: tx.senderAccount.firstName,
@@ -370,6 +372,7 @@ export class TransactionsService {
       const transaction = await this.transactionsRepository.findOne({
         where: { id: transactionId },
         relations: {
+          regret:true,
           senderAccount: {
             paymentMethod: true,
           },


### PR DESCRIPTION
Descripción
- Se agregó la relación `regret` en TransactionResponseDto con RegretDto.
- Se actualizó el servicio de creación de regrets para asignarlo automáticamente a la transacción.
- Se incluyó `regretId` en la respuesta de la transacción.
- Se actualizó `find` y `getTransactionByEmail` para incluir la relación `regret`.

Este PR permite que las transacciones devuelvan correctamente la información del regret asociado. Se incluyen `regret` completo y `regretId` en la respuesta, y se asegura que al crear un regret se actualice la transacción correspondiente.
