### PR TITLE
feat(user-verification): Agregar endpoint para validar usuario tras verificación aprobada

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -28,6 +28,7 @@ export class AuthService {
       profile: profile,
       category: profile.category ?? null,
       isValidated: user.isValidated,
+      userValidated: user.userValidated
     };
   }
 

--- a/src/modules/users/entities/user.entity.ts
+++ b/src/modules/users/entities/user.entity.ts
@@ -109,6 +109,9 @@ export class User {
   @Column({ name: 'is_validated', default: false })
   isValidated: boolean;
 
+  @Column({ name: 'user_validated', default: false })
+  userValidated: boolean;
+
   @Column({ nullable: true })
   refreshToken?: string;
 }


### PR DESCRIPTION
Descripción del Pull Request

Resumen:
Se agregó un nuevo endpoint POST /validate-user que permite marcar a un usuario como validado (userValidated = true) si su verificación se encuentra en estado aprobado (VERIFIED). Esto mejora el flujo de verificación de usuarios, asegurando que solo aquellos con verificación aprobada puedan ser marcados como validados.

Cambios realizados:
-Se añadió la propiedad userValidated al payload del JWT generado para reflejar el estado actualizado del usuario.
-Se corrigió el método findByUserId en UserVerificationService para incluir la relación user y evitar errores al acceder a verification.user.userValidated.
-Se implementó el método validateUserIfApproved en UserVerificationService que actualiza userValidated a true solo si la verificación está aprobada, lanzando un BadRequestException si no lo está.
-Se creó el endpoint POST /validate-user en UserVerificationController con documentación Swagger completa, validaciones y guardias (RolesGuard).
-El controlador ahora devuelve la verificación y el estado actualizado userValidated en la respuesta.

Beneficios:
-Mejora la consistencia de los estados de usuario y verificación.
-Previene que usuarios no verificados puedan ser marcados como validados.
-Integra userValidated en el JWT para su uso en autenticación y autorización.