### PR TITLE
refactor(userAccounts): cambio de account_id a accountId en camelCase diferenciando IDs en details y UserAccount, y ajustando todas las relaciones y demás

### DIFF
--- a/src/modules/userAccounts/entities/user-account.entity.ts
+++ b/src/modules/userAccounts/entities/user-account.entity.ts
@@ -10,7 +10,7 @@ import {
 @Entity('user_account')
 export class UserAccount {
   @PrimaryGeneratedColumn('uuid', { name: 'account_id' })
-  account_id: string;
+  accountId: string;
 
   @Column({ name: 'account_name', nullable: true })
   accountName: string;

--- a/src/modules/userAccounts/entities/user-bank.entity.ts
+++ b/src/modules/userAccounts/entities/user-bank.entity.ts
@@ -29,6 +29,6 @@ export class UserBank {
   accountId: string;
 
   @ManyToOne(() => UserAccount)
-  @JoinColumn({ name: 'account_id', referencedColumnName: 'account_id' })
+  @JoinColumn({ name: 'account_id', referencedColumnName: 'accountId' })
   userAccount: UserAccount;
 }

--- a/src/modules/userAccounts/entities/user-pix.entity.ts
+++ b/src/modules/userAccounts/entities/user-pix.entity.ts
@@ -20,6 +20,6 @@ export class UserPix {
   accountId: string;
 
   @ManyToOne(() => UserAccount)
-  @JoinColumn({ name: 'account_id', referencedColumnName: 'account_id' })
+  @JoinColumn({ name: 'account_id', referencedColumnName: 'accountId' })
   userAccount: UserAccount;
 }

--- a/src/modules/userAccounts/entities/user-receiver-crypto.entity.ts
+++ b/src/modules/userAccounts/entities/user-receiver-crypto.entity.ts
@@ -19,6 +19,6 @@ export class UserReceiverCrypto {
   accountId: string;
 
   @ManyToOne(() => UserAccount)
-  @JoinColumn({ name: 'account_id', referencedColumnName: 'account_id' })
+  @JoinColumn({ name: 'account_id', referencedColumnName: 'accountId' })
   userAccount: UserAccount;
 }

--- a/src/modules/userAccounts/entities/user-virtual-bank.entity.ts
+++ b/src/modules/userAccounts/entities/user-virtual-bank.entity.ts
@@ -29,6 +29,6 @@ export class UserVirtualBank {
   lastName: string;
 
   @ManyToOne(() => UserAccount)
-  @JoinColumn({ name: 'account_id', referencedColumnName: 'account_id' })
+  @JoinColumn({ name: 'account_id', referencedColumnName: 'accountId' })
   userAccount: UserAccount;
 }

--- a/src/modules/userAccounts/userAccounts.service.ts
+++ b/src/modules/userAccounts/userAccounts.service.ts
@@ -65,7 +65,7 @@ export class AccountsService {
         specificAccount = this.virtualBankRepo.create({
           accountType: userAccValues.accountType,
           currency: userAccValues.currency,
-          accountId: savedUserAccount.account_id,
+          accountId: savedUserAccount.accountId,
           type: userAccValues.type,
           email: userAccValues.email,
           firstName: userAccValues.firstName,
@@ -108,7 +108,8 @@ export class AccountsService {
   async deleteBankAccount(user: any, bankAccountId: string) {
     // Busca la cuenta principal del usuario
     const userAccount = await this.userAccountRepo.findOne({
-      where: { account_id: bankAccountId, userId: user.id },
+      where: { accountId: bankAccountId, userId: user.id },
+
     });
 
     if (!userAccount) {
@@ -136,7 +137,7 @@ export class AccountsService {
     }
 
     // Elimina la cuenta principal
-    await this.userAccountRepo.delete({ account_id: bankAccountId });
+    await this.userAccountRepo.delete({ accountId: bankAccountId });
 
     return { message: 'Cuenta eliminada correctamente' };
   }
@@ -154,35 +155,35 @@ export class AccountsService {
     const enrichedAccounts = await Promise.all(
       accounts.map(async (account) => {
         const typeId = account.accountType;
-        const { account_id } = account;
+        const { accountId } = account;
 
         let details: any[] = [];
 
         switch (typeId) {
           case Platform.Bank:
             details = await this.bankAccountRepo.find({
-              where: { userAccount: { account_id } },
+              where: { userAccount: { accountId } },
               relations: ['userAccount'],
             });
             break;
 
           case Platform.Pix:
             details = await this.pixRepo.find({
-              where: { userAccount: { account_id } },
+              where: { userAccount: { accountId } },
               relations: ['userAccount'],
             });
             break;
 
           case Platform.Virtual_Bank:
             details = await this.virtualBankRepo.find({
-              where: { userAccount: { account_id } },
+              where: { userAccount: { accountId } },
               relations: ['userAccount'],
             });
             break;
 
           case Platform.Receiver_Crypto:
             details = await this.receiverCryptoRepo.find({
-              where: { userAccount: { account_id } },
+              where: { userAccount: { accountId } },
               relations: ['userAccount'],
             });
             break;
@@ -193,7 +194,7 @@ export class AccountsService {
 
         // Mapear los detalles de forma segura, evitando undefined
         const mappedDetails = details.map((d) => ({
-          account_id: d.account_id ?? d.bankId ?? d.receiver_crypto ?? d.virtual_bank_id,
+          detailId: d.account_id ?? d.bankId ?? d.receiver_crypto ?? d.virtual_bank_id,
           currency: d.currency,
           type: d.type,
           accountName: d.accountName,
@@ -235,14 +236,15 @@ export class AccountsService {
     }
 
     //  Si pasamos bankAccountId, filtramos
-    const found = allBanks.find((bank) => bank.details.some((d) => d.account_id === bankAccountId));
+    const found = allBanks.find((bank) => bank.details.some((d) => d.detailId === bankAccountId));
+
 
     if (!found) {
       throw new NotFoundException('Cuenta no encontrada para este usuario');
     }
 
     //  Filtramos los detalles para devolver solo el que coincide
-    const filteredDetails = found.details.filter((d) => d.account_id === bankAccountId);
+    const filteredDetails = found.details.filter((d) => d.detailId === bankAccountId);
 
     return {
       ...found,


### PR DESCRIPTION
refactor(userAccounts): cambio de account_id a accountId en camelCase diferenciando IDs en details y userAccount, y ajustando todas las relaciones y demás (#112)


Contexto

Actualmente, en las respuestas del endpoint GET /api/v2/users/accounts, el campo account_id aparece en formato snake_case tanto en details como en userAccount. Esto generaba inconsistencia con la convención de camelCase utilizada en el resto del sistema y confusión respecto a qué ID correspondía a cada entidad.


Cambios realizados

Se renombró account_id → accountId en todas las entidades (UserAccount, UserBank, UserPix, UserReceiverCrypto, UserVirtualBank).

Se diferenciaron los identificadores:

details.detailId → para los registros secundarios (ej. bancos, pix, wallets, etc).

userAccount.accountId → para el identificador principal de la cuenta de usuario.

Se ajustaron las relaciones en TypeORM (@JoinColumn) y los servicios asociados para reflejar correctamente la convención camelCase.

No fue necesario crear migraciones, ya que las columnas en la base de datos se mantienen en snake_case; los cambios se aplicaron a nivel de entidades/DTOs/API.


Impacto

Las respuestas de la API ahora son consistentes con la convención camelCase, facilitando su consumo en frontend.

Se reduce la ambigüedad entre los IDs de details y userAccount, aportando mayor claridad en los contratos de la API.

El backend se mantiene estable y funcionando correctamente.


Cómo probarlo

Levantar el backend con la rama refactor/userAccounts-camelcase-accountid.

Ejecutar el endpoint GET /api/v2/users/accounts


Verificar que:

Los campos aparecen en camelCase (accountId, detailId).

userAccount.accountId y details.detailId están claramente diferenciados.

Las relaciones y datos retornados se mantienen correctos.
