### PR TITLE
feat: agregar firstName y lastName al DTO de receiver en transacciones

### DIFF
--- a/src/modules/transactions/dto/transaction-response.dto.ts
+++ b/src/modules/transactions/dto/transaction-response.dto.ts
@@ -129,6 +129,14 @@ export class AccountReceiverDto {
   id: string;
 
   @Expose()
+  @ApiProperty({ name: 'firstName', example: 'Juan' })
+  firstName: string;
+
+  @Expose()
+  @ApiProperty({ name: 'lastName', example: 'Pérez' })
+  lastName: string;
+
+  @Expose()
   @Type(() => PaymentMethodReceiverDto)
   @ApiProperty({ name: 'paymentMethod', type: PaymentMethodReceiverDto })
   paymentMethod: PaymentMethodReceiverDto;


### PR DESCRIPTION
Descripción del PR

Este PR agrega los campos firstName y lastName al AccountReceiverDto, asegurando que la información del receptor se devuelva correctamente en las respuestas de transacciones.

Cambios principales:
-Se añadieron los campos firstName y lastName al AccountReceiverDto.
-Se preparó la documentación (ClickUp) con ejemplos actualizados de request y response para Create Transaction.

Impacto:
Las respuestas de transacciones ahora mostrarán información completa del receiver.