### PR TITLE
feat(admin-transactions): incluir regret_id en listado y request completo en detalle

### DIFF
--- a/src/modules/admin/admin.service.ts
+++ b/src/modules/admin/admin.service.ts
@@ -73,6 +73,7 @@ export class AdminService {
         'amount',
         'proofOfPayment',
         'note',
+        'regret'
       ],
       skip: (page - 1) * perPage,
       take: perPage,
@@ -84,6 +85,7 @@ export class AdminService {
       message: tx.message,
       createdAt: tx.createdAt.toISOString(),
       finalStatus: tx.finalStatus,
+      regret: tx.regret && { regretId: tx.regret.id },
       senderAccount: {
         id: tx.senderAccount.id,
         firstName: tx.senderAccount.firstName,
@@ -135,6 +137,7 @@ export class AdminService {
         'amount',
         'proofOfPayment',
         'note',
+        'regret'
       ],
     });
 
@@ -191,6 +194,7 @@ export class AdminService {
       message: transaction.message,
       createdAt: transaction.createdAt.toISOString(),
       finalStatus: transaction.finalStatus,
+      regret: transaction.regret,
       senderAccount: this.removeNulls({
         id: sender.id,
         firstName: sender.firstName,


### PR DESCRIPTION
📝 Descripción

Este PR implementa las siguientes mejoras en los endpoints de administración de transacciones:

GET /api/v2/admin/transactions
Se añade el campo regret_id en la respuesta de cada transacción.

GET /api/v2/admin/transactions/{id}
Ahora retorna la request completa del regret asociada a la transacción.

Con estos cambios, se facilita la gestión y análisis de solicitudes de arrepentimiento desde el panel administrativo. ✅