### PR TITLE
Refactor: Unificar relación Regret-Transaction y eliminar campo redundante

### DIFF
--- a/src/modules/transactions/regrets/entities/regrets.entity.ts
+++ b/src/modules/transactions/regrets/entities/regrets.entity.ts
@@ -1,14 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToOne, JoinColumn, Transaction } from 'typeorm';
-import { Transaction as TransactionEntity } from '@transactions/entities/transaction.entity';
+import { Entity, PrimaryGeneratedColumn, Column, OneToOne, JoinColumn } from 'typeorm';
+import { Transaction } from '@transactions/entities/transaction.entity';
 import { ProofOfPayment } from '@financial-accounts/proof-of-payments/entities/proof-of-payment.entity';
 
 @Entity('regrets')
 export class Regret {
   @PrimaryGeneratedColumn('uuid', { name: 'regret_id' })
   id: string;
-
-  @Column({ type: 'varchar', name: 'transaction_id' })
-  transaction_id: string;
 
   @Column({ type: 'varchar', name: 'last_name' })
   last_name: string;
@@ -22,18 +19,13 @@ export class Regret {
   @Column({ type: 'varchar', name: 'description' })
   description: string;
 
-  //FK -> transaction_payment_info.payment_info_id  //relations
-  // @Column({ type: 'varchar', name: 'payment_info_id' })
-  // payment_info_id: string;
+  @OneToOne(() => Transaction, (transaction) => transaction.regret, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'transaction_id' })  
+  transaction: Transaction;
 
-  //onetoone ?
-  @OneToOne(() => TransactionEntity, (transaction) => transaction.regret)
-  @JoinColumn({ name: 'transaction_id' })
-  transaction: TransactionEntity;
-
-  @OneToOne(() => ProofOfPayment)
+  @OneToOne(() => ProofOfPayment, { nullable: true, onDelete: 'SET NULL' })
   @JoinColumn({ name: 'payment_info_id' })
-  proofOfPayment: ProofOfPayment;
+  proofOfPayment?: ProofOfPayment;
 }
 
 /* regrets [icon: x-circle, color: orange] {


### PR DESCRIPTION
Descripción del PR:

Resumen:
Este PR refactoriza la entidad Regret eliminando el campo transaction_id redundante y unifica la relación con Transaction usando únicamente @OneToOne con @JoinColumn. 

Cambios principales:

Eliminación de transaction_id de Regret.

Relación Regret <-> Transaction manejada solo con @OneToOne.

Actualización de imports para usar Transaction en lugar de TransactionEntity.