### PR TITLE
Remover `paymentsId` del flujo de creación de transacciones

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -50,7 +50,6 @@ export class AuthService {
   }
 
   async refreshAccessToken(refreshToken: string) {
-    console.log('🧪 Buscando usuario con refreshToken:', refreshToken);
     const user = await this.userRepo.findOne({
       where: { refreshToken },
       relations: ['profile'],

--- a/src/modules/transactions/dto/create-transaction.dto.ts
+++ b/src/modules/transactions/dto/create-transaction.dto.ts
@@ -6,15 +6,6 @@ import { Type } from 'class-transformer';
 
 export class CreateTransactionDto {
   @ApiProperty({
-    name: 'paymentsId',
-    description: 'ID único del pago o transacción',
-    example: '123',
-  })
-  @IsString({ message: 'paymentsId debe ser un texto' })
-  @IsNotEmpty({ message: 'paymentsId es obligatorio' })
-  paymentsId: string;
-
-  @ApiProperty({
     name: 'countryTransaction',
     description: 'País donde se realiza la transacción',
     example: 'Argentina',

--- a/src/modules/transactions/transactions.controller.spec.ts
+++ b/src/modules/transactions/transactions.controller.spec.ts
@@ -45,7 +45,8 @@ describe('TransactionsController (integración real)', () => {
               ),
             findOne: jest.fn().mockImplementation((options) =>
               Promise.resolve({
-                paymentsId: 'tx-123',
+                // paymentsId: 'tx-123', // eliminado
+                id: 'tx-123',
                 countryTransaction: 'Argentina',
                 message: 'Test',
                 createdAt: new Date().toISOString(),
@@ -132,7 +133,7 @@ describe('TransactionsController (integración real)', () => {
 
   it('crea transacción con método de pago virtual-bank', async () => {
     const dto = {
-      paymentsId: 'tx-123',
+      // paymentsId: 'tx-123', // eliminado
       countryTransaction: 'Argentina',
       message: 'Test',
       createdBy: 'dev@correo.com',
@@ -183,9 +184,9 @@ describe('TransactionsController (integración real)', () => {
 
     const result = await controller.create({ createTransactionDto: JSON.stringify(dto) }, file);
 
-    // Verifica los campos más importantes
     expect(result.senderAccount.firstName).toBe('Pedro');
     expect(result.senderAccount.paymentMethod.platformId).toBe('virtual_bank');
     expect(result.receiverAccount.paymentMethod.bankName).toBe('Banco Galicia');
+    expect(result).not.toHaveProperty('paymentsId'); // opcional
   });
 });

--- a/src/modules/transactions/transactions.controller.ts
+++ b/src/modules/transactions/transactions.controller.ts
@@ -88,7 +88,6 @@ export class TransactionsController {
             'JSON stringificado con la información de la transacción (CreateTransactionDto)',
           example: JSON.stringify(
             {
-              paymentsId: '126',
               countryTransaction: 'Argentina',
               message: 'Transferencia Crypto',
               financialAccounts: {
@@ -181,7 +180,6 @@ export class TransactionsController {
     // Validación de campos obligatorios del DTO
     const requiredFields: (keyof CreateTransactionDto)[] = [
       'countryTransaction',
-      'paymentsId',
       'financialAccounts',
       'amount',
     ];

--- a/src/test/transactions/transactions.test.e2e-spec.ts
+++ b/src/test/transactions/transactions.test.e2e-spec.ts
@@ -64,7 +64,7 @@ describe('ENDPOINT DE TRANSACCIONES #api #tra', () => {
 
   it('Cuando se envían datos válidos y un archivo, se crea la transacción y se envía email', async () => {
     const createTransactionDto = {
-      paymentsId: '123',
+      // paymentsId: '123', // eliminado: no se almacena en la DB ni es requerido
       countryTransaction: 'Argentina',
       message: 'Transferencia de prueba',
       financialAccounts: {
@@ -123,5 +123,6 @@ describe('ENDPOINT DE TRANSACCIONES #api #tra', () => {
     expect(body.senderAccount).toHaveProperty('firstName', 'Juan');
     expect(body.receiverAccount.paymentMethod.bank).toHaveProperty('bankName', 'Banco Galicia');
     expect(body.amount).toHaveProperty('amountSent', '1000.00');
+    expect(body).not.toHaveProperty('paymentsId'); // opcional: confirma que no se devuelve
   });
 });


### PR DESCRIPTION
### 📄 Descripción

Este pull request elimina el campo `paymentsId` de todo el flujo de creación de transacciones, incluyendo DTOs, controladores, validaciones y pruebas automatizadas. Con estos cambios, el campo ya no es requerido, almacenado ni devuelto en las operaciones relacionadas con transacciones.

**Cambios principales:**

* **DTOs:**

  * Eliminado `paymentsId` y sus validaciones en `CreateTransactionDto`.

* **Controlador:**

  * Eliminadas referencias a `paymentsId` en `TransactionsController`.
  * Actualizada la documentación de la API para reflejar los campos requeridos.

* **Pruebas:**

  * Ajustados tests unitarios e integraciones para remover `paymentsId` de los datos de prueba.
  * Verificaciones agregadas para confirmar que `paymentsId` no se devuelve en las respuestas.
  * End-to-end tests actualizados para garantizar consistencia en la creación de transacciones sin este campo.

* **Limpieza menor:**

  * Eliminado un `console.log` de depuración en `AuthService`.
