### PR TITLE
Agregar validación de números de teléfono internacionales en transacciones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "handlebars": "^4.7.8",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
+        "libphonenumber-js": "^1.12.16",
         "nanoid": "^3.3.11",
         "nodemailer": "^7.0.3",
         "otp-generator": "^4.0.1",
@@ -8315,9 +8316,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.12.8",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.8.tgz",
-      "integrity": "sha512-f1KakiQJa9tdc7w1phC2ST+DyxWimy9c3g3yeF+84QtEanJr2K77wAmBPP22riU05xldniHsvXuflnLZ4oysqA==",
+      "version": "1.12.16",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.16.tgz",
+      "integrity": "sha512-Ut/2lKjVnoVayb0dVUxWzGO5UB57bTcuJr41W6MQ2V8YolOsHWEah6I0bO5LQ71SY6WYZd3e4A4Z9r4B6zQC2g==",
       "license": "MIT"
     },
     "node_modules/lines-and-columns": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "handlebars": "^4.7.8",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
+    "libphonenumber-js": "^1.12.16",
     "nanoid": "^3.3.11",
     "nodemailer": "^7.0.3",
     "otp-generator": "^4.0.1",

--- a/src/common/decorators/phone-number.decorator.ts
+++ b/src/common/decorators/phone-number.decorator.ts
@@ -1,0 +1,33 @@
+import { registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator';
+import { parsePhoneNumberFromString } from 'libphonenumber-js';
+
+export function IsPhoneNumberValid(validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'isPhoneNumberValid',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any, args: ValidationArguments) {
+          if (!value) return true; // si el campo es opcional, permitir vacío
+          if (typeof value !== 'string') return false;
+
+          // Debe empezar con "+" para que sea internacional
+          if (!value.startsWith('+')) return false;
+
+          try {
+            const phoneNumber = parsePhoneNumberFromString(value.trim());
+            // Validar solo si parsea correctamente
+            return !!phoneNumber && phoneNumber.isValid();
+          } catch {
+            return false; // cualquier error se considera inválido
+          }
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `El número "${args.value}" no es válido. Debe estar en formato internacional (+<código_pais><numero>).`;
+        },
+      },
+    });
+  };
+}

--- a/src/modules/financial-accounts/sender-financial-accounts/dto/create-sender-financial-account.dto.ts
+++ b/src/modules/financial-accounts/sender-financial-accounts/dto/create-sender-financial-account.dto.ts
@@ -1,3 +1,4 @@
+import { IsPhoneNumberValid } from '@common/decorators/phone-number.decorator';
 import { CreatePaymentMethodDto } from '@financial-accounts/payment-methods/dto/create-payment-method.dto';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
@@ -17,20 +18,21 @@ export class CreateSenderFinancialAccountDto {
   @ApiProperty({
     description: 'Correo electrónico',
     example: 'nahuel@example.com',
-    required: false,
+    required: true,
   })
   @IsEmail()
-  @IsOptional()
+  @IsNotEmpty()
   createdBy: string;
 
   @ApiProperty({
-    description: 'Número de teléfono',
-    example: '1122334455',
-    required: false,
+    description: 'Número de teléfono en formato internacional. Ej: +56912345678',
+    example: '+573001234567',
+    required: true,
   })
   @IsString()
-  @IsOptional()
-  phoneNumber?: string;
+  @IsNotEmpty()
+  @IsPhoneNumberValid({ message: 'Número inválido según su código de país. Use formato +<código_pais><numero>.' })
+  phoneNumber: string;
 
   @ApiProperty()
   @ValidateNested()


### PR DESCRIPTION
Descripción del PR:

Resumen:
Se implementa una validación para asegurar que los números de teléfono en el CreateSenderFinancialAccountDto estén en formato internacional válido. Además, se actualiza el endpoint de creación de transacciones para que valide el número antes de persistir los datos.

Cambios realizados:

-Creación del decorador IsPhoneNumberValid usando libphonenumber-js.
-Actualización del DTO CreateSenderFinancialAccountDto para usar la validación de números internacionales.
-Implementación de la validación adicional en el controlador transactions.controller.ts antes de llamar al servicio.
-Manejo de errores para retornar solo los mensajes de validación al cliente.

Beneficio:
Evita que se guarden números de teléfono inválidos, asegurando consistencia y correcta comunicación internacional en las transacciones.