### PR TITLE
feat: transferCode opcional en VirtualBank DTO y entidad

### DIFF
--- a/src/modules/financial-accounts/payment-methods/virutal-bank/dto/create-virtual-bank.dto.ts
+++ b/src/modules/financial-accounts/payment-methods/virutal-bank/dto/create-virtual-bank.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmpty, IsNotEmpty, IsString } from 'class-validator';
+import { IsEmpty, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateVirtualBankDto {
   @ApiProperty({ description: 'Moneda', example: 'ARS' })
@@ -17,6 +17,6 @@ export class CreateVirtualBankDto {
 
   @ApiProperty({ description: 'Codigo de transferencia', example: '123' })
   @IsString()
-  @IsNotEmpty()
-  transferCode: string;
+  @IsOptional() // ahora es opcional
+  transferCode?: string;
 }

--- a/src/modules/financial-accounts/payment-methods/virutal-bank/entities/virtual-bank.entity.ts
+++ b/src/modules/financial-accounts/payment-methods/virutal-bank/entities/virtual-bank.entity.ts
@@ -9,6 +9,6 @@ export class VirtualBank extends PaymentMethod {
   @Column({ name: 'email_account' })
   emailAccount: string;
 
-  @Column({ name: 'transfer_code' })
-  transferCode: string;
+  @Column({ name: 'transfer_code' , nullable: true})
+  transferCode?: string;
 }

--- a/src/modules/userAccounts/dto/create-user-account.dto.ts
+++ b/src/modules/userAccounts/dto/create-user-account.dto.ts
@@ -8,11 +8,9 @@ export class CreateUserAccountDto extends CreatePaymentMethodDto {
 
   @IsOptional()
   @IsString()
-  @IsNotEmpty()
   firstName?: string;
 
   @IsOptional()
   @IsString()
-  @IsNotEmpty()
   lastName?: string;
 }


### PR DESCRIPTION
Resumen:
Se modifica la funcionalidad de VirtualBank para que el campo transferCode sea opcional. Esto aplica tanto al DTO de creación como a la entidad, permitiendo que las cuentas virtuales puedan crearse sin necesidad de proveer un código de transferencia.

Cambios realizados:

Se actualizó CreateVirtualBankDto agregando @IsOptional() y haciendo transferCode opcional (?).

Se modificó la entidad VirtualBank para que la columna transfer_code sea nullable (nullable: true).