### PR TITLE
fix(discounts, dto): resolve 500 error on user-discounts and expose document fields in transaction responses 

### DIFF
--- a/src/discounts/entities/user-discount.entity.ts
+++ b/src/discounts/entities/user-discount.entity.ts
@@ -5,7 +5,6 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   ManyToOne,
-  OneToMany,
   JoinColumn,
   ManyToMany,
 } from 'typeorm';

--- a/src/modules/transactions/dto/transaction-response.dto.ts
+++ b/src/modules/transactions/dto/transaction-response.dto.ts
@@ -408,6 +408,26 @@ export class PaymentMethodGetReceiverDto {
   @IsString()
   sendMethodValue?: string;
 
+  @Expose()
+  @ApiProperty({
+    description: 'Tipo de documento (Bank)',
+    example: 'DNI',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  documentType?: string;
+
+  @Expose()
+  @ApiProperty({
+    description: 'Número de documento (Bank)',
+    example: '12345678',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  documentValue?: string;
+
   // PIX
   @Expose()
   @ApiProperty({
@@ -583,3 +603,4 @@ export class TransactionGetResponseDto {
   amount: AmountDto;
   
 }
+

--- a/src/modules/transactions/entities/transaction.entity.ts
+++ b/src/modules/transactions/entities/transaction.entity.ts
@@ -97,13 +97,13 @@ export class Transaction {
   @Column({ type: 'varchar', length: 3, name: 'amount_currency', nullable: true })
   amountCurrency?: string;
 
-  @ManyToMany(() => UserDiscount)
+  @ManyToMany(() => UserDiscount, (ud) => ud.transactions)
   @JoinTable({
     name: 'transaction_user_discounts',
     joinColumn: { name: 'transaction_id', referencedColumnName: 'id' },
     inverseJoinColumn: { name: 'user_discount_id', referencedColumnName: 'id' },
   })
-  userDiscounts?: UserDiscount[];
+  userDiscounts: UserDiscount[];
 
   @Column({ default: false })
   isNoteVerified: boolean;


### PR DESCRIPTION
fix(discounts, dto): resolve 500 error on user-discounts and expose document fields in transaction responses (#144)

Se corrige el error 500 en los endpoints GET /api/v2/discounts/user-discounts ajustando la relación entre Transaction y UserDiscount.

Además, se exponen los campos documentType y documentValue en PaymentMethodGetReceiverDto para alinear las respuestas de las transacciones.