### PR TITLE
Implementar administración de perfiles de usuario con endpoints CRUD y documentación Swagger

### DIFF
--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -18,6 +18,7 @@ import { AdminProfileController } from './profiles/admin-profile.controller';
 import { AdminTransactionController } from './transaction/admin-transaction.controller';
 import { AdminTransactionService } from './transaction/admin-transaction.service'; // <-- import service
 import { UserSocials } from '@users/entities/user-socials.entity';
+import { AdminProfileService } from './profiles/admin-profile.service';
 
 @Module({
   imports: [
@@ -45,6 +46,7 @@ import { UserSocials } from '@users/entities/user-socials.entity';
   providers: [
     ProfileService,
     AdminTransactionService,
+    AdminProfileService
   ],
   exports: [],
 })

--- a/src/modules/admin/dto/admin-profile-response.dto.ts
+++ b/src/modules/admin/dto/admin-profile-response.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AdminProfileResponseDto {
+  @ApiProperty({
+    description: 'Fecha de registro del usuario',
+    example: '2025-09-25T14:42:52.378Z',
+  })
+  fechaRegistro: string;
+
+  @ApiProperty({
+    description: 'ID del usuario',
+    example: 'f3282e57-aaa6-4263-9b17-7db1992d4d76',
+  })
+  userId: string;
+
+  @ApiProperty({
+    description: 'ID del perfil',
+    example: 'e997eb7b-dc81-4a3b-91f4-784bd76da2d2',
+  })
+  profileId: string;
+
+  @ApiProperty({
+    description: 'Nombre completo del usuario',
+    example: 'Juan Pérez',
+  })
+  nombre: string;
+
+  @ApiProperty({
+    description: 'Correo electrónico del usuario',
+    example: 'example@gmail.com',
+  })
+  email: string;
+
+  @ApiProperty({
+    description: 'Teléfono del usuario',
+    example: '+573001112233',
+  })
+  telefono: string;
+
+  @ApiProperty({
+    description: 'País del usuario',
+    example: 'Colombia',
+  })
+  pais: string;
+}

--- a/src/modules/admin/dto/update-admin-profile-response.dto.ts
+++ b/src/modules/admin/dto/update-admin-profile-response.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateAdminProfileResponseDto {
+  @ApiProperty({
+    description: 'ID del perfil actualizado',
+    example: 'e997eb7b-dc81-4a3b-91f4-784bd76da2d2',
+  })
+  profileId: string;
+
+  @ApiProperty({
+    description: 'ID del usuario asociado',
+    example: 'f3282e57-aaa6-4263-9b17-7db1992d4d76',
+  })
+  userId: string;
+
+  @ApiProperty({
+    description: 'Nombre actualizado',
+    example: 'Juan',
+  })
+  firstName: string;
+
+  @ApiProperty({
+    description: 'Apellido actualizado',
+    example: 'Pérez',
+  })
+  lastName: string;
+
+  @ApiProperty({
+    description: 'Apodo o nickname',
+    example: 'JPDev',
+  })
+  nickName: string;
+
+  @ApiProperty({
+    description: 'Correo electrónico actualizado',
+    example: 'example@gmail.com',
+  })
+  email: string;
+
+  @ApiProperty({
+    description: 'Teléfono actualizado',
+    example: '+573001112233',
+  })
+  phone: string;
+}

--- a/src/modules/admin/dto/update-admin-profile.dto.ts
+++ b/src/modules/admin/dto/update-admin-profile.dto.ts
@@ -1,0 +1,44 @@
+import { IsEmail, IsOptional, IsString, IsPhoneNumber } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateAdminProfileDto {
+  @ApiPropertyOptional({
+    description: 'Nombre del usuario',
+    example: 'Juan',
+  })
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @ApiPropertyOptional({
+    description: 'Apellido del usuario',
+    example: 'Pérez',
+  })
+  @IsOptional()
+  @IsString()
+  lastName?: string;
+
+  @ApiPropertyOptional({
+    description: 'Apodo o nickname del usuario',
+    example: 'JPDev',
+  })
+  @IsOptional()
+  @IsString()
+  nickName?: string;
+
+  @ApiPropertyOptional({
+    description: 'Correo electrónico del usuario',
+    example: 'juanperez@gmail.com',
+  })
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @ApiPropertyOptional({
+    description: 'Número de teléfono del usuario',
+    example: '+573001112233',
+  })
+  @IsOptional()
+  @IsPhoneNumber('CO')
+  phone?: string;
+}

--- a/src/modules/admin/profiles/admin-profile.service.ts
+++ b/src/modules/admin/profiles/admin-profile.service.ts
@@ -1,0 +1,97 @@
+import { UpdateAdminProfileDto } from '@admin/dto/update-admin-profile.dto';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserProfile } from '@users/entities/user-profile.entity';
+import { Repository } from 'typeorm';
+
+
+@Injectable()
+export class AdminProfileService {
+  constructor(
+    @InjectRepository(UserProfile)
+    private readonly profileRepository: Repository<UserProfile>,
+  ) {}
+
+  // Obtener todos los usuarios registrados (ADMIN)
+  async findAll() {
+  const profiles = await this.profileRepository.find({
+    relations: ['user', 'user.locations'],
+  });
+
+  if (!profiles || profiles.length === 0) {
+    throw new NotFoundException(`No se encontraron usuarios`);
+  }
+
+  // Mapeo de los datos a la estructura deseada
+  const mappedProfiles = profiles.map(profile => {
+    return {
+      fechaRegistro: profile.user.createdAt, 
+      userId: profile.user.id,              
+      profileId: profile.id,                
+      nombre: `${profile.firstName} ${profile.lastName}`, 
+      email: profile.email,                 
+      telefono: profile.phone,              
+      pais: profile.user.locations?.[0]?.country || null, 
+    };
+  });
+
+  return {
+    message: 'Perfiles obtenidos correctamente',
+    result: mappedProfiles,
+  };
+}
+
+async updateAdminProfile(profileId: string, updateProfileDto: UpdateAdminProfileDto) {
+  const profile = await this.profileRepository.findOne({
+    where: { id: profileId },
+    relations: ['user'],
+  });
+
+  if (!profile) return null;
+
+  Object.assign(profile, updateProfileDto);
+
+  await this.profileRepository.save(profile);
+
+  const reloadedProfile = await this.profileRepository.findOne({
+  where: { id: profileId },
+  relations: ['user'], 
+});
+
+if (!reloadedProfile) {
+  throw new NotFoundException('Perfil no encontrado después de actualizar');
+} 
+
+return {
+  message: 'Perfil actualizado correctamente',
+  result: {
+    profileId: reloadedProfile.id,
+    userId: reloadedProfile.user.id,
+    firstName: reloadedProfile.firstName,
+    lastName: reloadedProfile.lastName,
+    nickName: reloadedProfile.nickName ,
+    email: reloadedProfile.email,
+    phone: reloadedProfile.phone,
+  },
+};
+}
+
+  async deleteUserById(id: string) {
+    const profile = await this.profileRepository.findOne({
+      where: { user: { id } },
+    });
+
+    if (!profile) {
+      throw new NotFoundException(`Perfil con ID de usuario ${id} no encontrado`);
+    }
+
+    await this.profileRepository.remove(profile);
+
+    return { message: 'User profile deleted successfully!' };
+  }
+}

--- a/src/modules/users/profile/profile.service.ts
+++ b/src/modules/users/profile/profile.service.ts
@@ -27,19 +27,6 @@ export class ProfileService {
     private readonly fileUploadService: FileUploadService,
   ) {}
 
-  // Obtener todos los usuarios registrados (ADMIN)
-async findAll() {
-  const profiles = await this.profileRepository.find({
-    relations: ['user', 'user.locations'], 
-  });
-
-  if (!profiles || profiles.length === 0) {
-    throw new NotFoundException(`No se encontraron usuarios`);
-  }
-
-  return profiles;
-}
-
   async getUserProfileById(userId: string) {
   const profile = await this.profileRepository.findOne({
     where: { user: { id: userId } },
@@ -113,19 +100,6 @@ async findByEmail(email: string) {
     return this.profileRepository.save(profile);
   }
 
-  async deleteUserById(id: string) {
-    const profile = await this.profileRepository.findOne({
-      where: { user: { id } },
-    });
-
-    if (!profile) {
-      throw new NotFoundException(`Perfil con ID de usuario ${id} no encontrado`);
-    }
-
-    await this.profileRepository.remove(profile);
-
-    return { message: 'User profile deleted successfully!' };
-  }
 
 async updateUserProfile(
   userId: string,


### PR DESCRIPTION
Descripción del Pull Request

Resumen:
-Se agregan y documentan los endpoints de administración de perfiles de usuario para permitir a los administradores:
-Listar todos los perfiles (GET /admin/profiles)
-Obtener perfil por ID (GET /admin/profiles/by-id)
-Obtener perfil por email (GET /admin/profiles/by-email)
-Actualizar datos básicos de un perfil (PATCH /admin/profiles/:id)
-Eliminar perfil de usuario (DELETE /admin/profiles)

Cambios principales:
-Se incorporó AdminProfileService para la lógica de administración.
-Se crean DTOs para entrada y salida (UpdateAdminProfileDto, UpdateAdminProfileResponseDto, AdminProfileResponseDto).
-Se eliminó refreshToken de la respuesta del usuario.
-Se unificó la estructura de respuesta: { message, result }.
-Se agregaron validaciones y guardias: JwtAuthGuard y AdminRoleGuard.
-Documentación Swagger completa con ejemplos y códigos de respuesta 200, 400, 401, 403 y 404.

Notas adicionales:
-Solo los administradores pueden acceder a estos endpoints.
-La actualización de perfil modifica solo los campos enviados y mantiene los existentes.
-Se respetan las relaciones de la base de datos (user.locations, socials).

Rama base: develop
Rama de la funcionalidad: feature/admin-profile-management