### PR TITLE
fix(discount): toggle user discount state, associate or disassociate transaction for admin

### DIFF
--- a/src/discounts/dto/user-discount-history.dto.ts
+++ b/src/discounts/dto/user-discount-history.dto.ts
@@ -66,7 +66,7 @@ export class UserDiscountHistoryDto {
 
   })
 
-  usedAt?: Date;
+  usedAt?: Date | null;
   
 }
 

--- a/src/discounts/entities/user-discount.entity.ts
+++ b/src/discounts/entities/user-discount.entity.ts
@@ -37,7 +37,7 @@ export class UserDiscount {
   createdAt: Date;
 
   @Column({ type: 'timestamp with time zone', name: 'used_at', nullable: true })
-  usedAt?: Date;
+  usedAt?: Date | null;
 
   @UpdateDateColumn({ type: 'timestamp with time zone', name: 'updated_at' })
   updatedAt: Date;

--- a/src/modules/transactions/dto/transaction-response.dto.ts
+++ b/src/modules/transactions/dto/transaction-response.dto.ts
@@ -268,7 +268,7 @@ export class UserDiscountGetDto {
 
   @Expose()
   @ApiProperty({ example: '2025-09-17T14:32:00.000Z', required: false })
-  usedAt?: Date;
+  usedAt?: Date | null;
 
 }
 


### PR DESCRIPTION

fix(discount): toggle user discount state, associate or disassociate transaction for admin

Contexto:
Se identificó que los administradores y super administradores no podían alternar correctamente el estado de uso de un descuento de usuario (userDiscount). El endpoint debía permitir:

Marcar un descuento como usado.

Desmarcar un descuento previamente usado.

Asociar o desasociar la transacción correspondiente si aplica.

Cambios realizados:

Se implementó la lógica de toggle del estado isUsed en UserDiscount y en archivos relacionados.

Se agregó soporte para desasociar la transacción si se desmarca el descuento.

Se asegura que si es necesario, la transacción se vuelva a asociar cuando se marque como usado nuevamente.

Se actualizaron los servicios y repositorios correspondientes sin afectar otras rutas o funcionalidades.

Impacto:

Ahora los administradores pueden alternar el estado de un descuento de usuario correctamente.

Se mantiene la consistencia de los registros en transaction_user_discounts.

Mejora en el manejo de cupones aplicados manualmente por el admin en situaciones donde la transacción falló o no se marcó correctamente.

Cómo probarlo:

Hacer un PUT a /api/v2/discounts/user-discounts/admin/{id} con un transactionId válido.

Verificar que al marcar el descuento como usado, se actualiza isUsed y se asocia la transacción si aplica.

Verificar que al desmarcar el descuento, isUsed se pone en false y la asociación con la transacción se elimina.

Confirmar que no se crean duplicados en transaction_user_discounts.